### PR TITLE
Chore: Require newer ayon core

### DIFF
--- a/package.py
+++ b/package.py
@@ -5,6 +5,6 @@ version = "0.3.10-dev.1"
 client_dir = "ayon_houdini"
 
 ayon_required_addons = {
-    "core": ">0.3.2",
+    "core": ">0.4.0",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Description
After PR https://github.com/ynput/ayon-core/pull/295 the addon require ayon-core > 0.4.0 .

## Additional information
This should be already part of that PR and ayon-houdini release 0.3.9 .