### PR TITLE
Load Asset LOP: Allow setting product type filters

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -132,7 +132,7 @@ def update_info(node, context):
     # Update the product type filter to match the type
     current = node.evalParm("product_type")
     product_type = context["product"]["productType"]
-    if current or current != product_type:
+    if current and current != product_type:
         # If current is empty we consider no filtering applied and we allow
         # that to be a state that needs no switching
         parms["product_type"] = product_type

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -129,6 +129,14 @@ def update_info(node, context):
              if node.evalParm(key) != value}
     parms["load_message"] = ""  # clear any warnings/errors
 
+    # Update the product type filter to match the type
+    current = node.evalParm("product_type")
+    product_type = context["product"]["productType"]
+    if current or current != product_type:
+        # If current is empty we consider no filtering applied and we allow
+        # that to be a state that needs no switching
+        parms["product_type"] = product_type
+
     # Note that these never trigger any parm callbacks since we do not
     # trigger the `parm.pressButton` and programmatically setting values
     # in Houdini does not trigger callbacks automatically

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -569,13 +569,16 @@ def get_available_products(node):
     if not folder_entity:
         return []
 
+    # Apply filter only if any value is set
+    product_types = [product_type] if product_type else None
+
     products = ayon_api.get_products(
         project_name,
         folder_ids=[folder_entity["id"]],
-        product_types=[product_type]
+        product_types=product_types
     )
 
-    return [product["name"] for product in products]
+    return list(sorted(product["name"] for product in products))
 
 
 def set_to_latest_version(node):

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
@@ -3,7 +3,7 @@
 {
     name	ayon::lop_import::1.0
     script	load_asset::1.0
-    label	"Load Asset"
+    label	"AYON Load Asset"
 
     help {
 	""
@@ -52,6 +52,12 @@
             label   "Product Type"
             type    string
             default { "usd" }
+            menu {
+                "usd"           "usd"
+                "pointcache"    "pointcache"
+                "model"         "model"
+                ""              "*"
+            }
         }
         parm {
             name    "product_name"

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
@@ -53,10 +53,11 @@
             type    string
             default { "usd" }
             menu {
-                "usd"           "usd"
-                "pointcache"    "pointcache"
-                "model"         "model"
                 ""              "*"
+                "camera"        "camera"
+                "model"         "model"
+                "pointcache"    "pointcache"
+                "usd"           "usd"
             }
         }
         parm {

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/OnCreated
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/OnCreated
@@ -2,5 +2,4 @@ node = kwargs["node"]
 hda_module = node.hdaModule()
 hda_module.setup_flag_changed_callback(node)
 
-node.parm("product_type").lock(True)
 node.parm("file").lock(True)


### PR DESCRIPTION
## Changes

- Allow product type filter to be set on Load Asset LOP.
- Set some sensible product type menu entries, including an option to have no filter applied `*`
- Sort the available products by name when listing them

Fixes #15 