### PR TITLE
Creators: Remove legacy `pop` of the 'active' data on create of instance.

### DIFF
--- a/client/ayon_houdini/plugins/create/create_alembic_camera.py
+++ b/client/ayon_houdini/plugins/create/create_alembic_camera.py
@@ -17,7 +17,6 @@ class CreateAlembicCamera(plugin.HoudiniCreator):
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "alembic"})
 
         instance = super(CreateAlembicCamera, self).create(

--- a/client/ayon_houdini/plugins/create/create_arnold_ass.py
+++ b/client/ayon_houdini/plugins/create/create_arnold_ass.py
@@ -20,7 +20,6 @@ class CreateArnoldAss(plugin.HoudiniCreator):
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "arnold"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())

--- a/client/ayon_houdini/plugins/create/create_arnold_rop.py
+++ b/client/ayon_houdini/plugins/create/create_arnold_rop.py
@@ -26,7 +26,6 @@ class CreateArnoldRop(plugin.HoudiniCreator):
                 creator_attributes[key] = pre_create_data[key]
 
         # Remove the active, we are checking the bypass flag of the nodes
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "arnold"})
 
         # Add chunk size attribute

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -15,8 +15,6 @@ class CreateBGEO(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
 
-        instance_data.pop("active", None)
-
         instance_data.update({"node_type": "geometry"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())

--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -19,7 +19,6 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
     def create(self, product_name, instance_data, pre_create_data):
         import hou  # noqa
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "comp"})
 
         instance = super(CreateCompositeSequence, self).create(

--- a/client/ayon_houdini/plugins/create/create_hda.py
+++ b/client/ayon_houdini/plugins/create/create_hda.py
@@ -250,14 +250,6 @@ class CreateHDA(plugin.HoudiniCreator):
 
         return hda_node
 
-    def create(self, product_name, instance_data, pre_create_data):
-        instance_data.pop("active", None)
-
-        return super(CreateHDA, self).create(
-            product_name,
-            instance_data,
-            pre_create_data)
-
     def get_network_categories(self):
         # Houdini allows creating sub-network nodes inside
         # these categories.

--- a/client/ayon_houdini/plugins/create/create_karma_rop.py
+++ b/client/ayon_houdini/plugins/create/create_karma_rop.py
@@ -24,7 +24,6 @@ class CreateKarmaROP(plugin.HoudiniCreator):
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "karma"})
         # Add chunk size attribute
         instance_data["chunkSize"] = 10

--- a/client/ayon_houdini/plugins/create/create_mantra_rop.py
+++ b/client/ayon_houdini/plugins/create/create_mantra_rop.py
@@ -23,7 +23,6 @@ class CreateMantraROP(plugin.HoudiniCreator):
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "ifd"})
         # Add chunk size attribute
         instance_data["chunkSize"] = 10

--- a/client/ayon_houdini/plugins/create/create_model.py
+++ b/client/ayon_houdini/plugins/create/create_model.py
@@ -17,7 +17,6 @@ from ayon_core.lib import BoolDef
 import hou
 
 
-
 class CreateModel(plugin.HoudiniCreator):
     """Create Model"""
     identifier = "io.openpype.creators.houdini.model"
@@ -26,7 +25,6 @@ class CreateModel(plugin.HoudiniCreator):
     icon = "cube"
 
     def create(self, product_name, instance_data, pre_create_data):
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "alembic"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())

--- a/client/ayon_houdini/plugins/create/create_pointcache.py
+++ b/client/ayon_houdini/plugins/create/create_pointcache.py
@@ -15,7 +15,6 @@ class CreatePointCache(plugin.HoudiniCreator):
     icon = "gears"
 
     def create(self, product_name, instance_data, pre_create_data):
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "alembic"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())

--- a/client/ayon_houdini/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_proxy.py
@@ -14,9 +14,6 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
 
-        # Remove the active, we are checking the bypass flag of the nodes
-        instance_data.pop("active", None)
-
         # Redshift provides a `Redshift_Proxy_Output` node type which shows
         # a limited set of parameters by default and is set to extract a
         # Redshift Proxy. However when "imprinting" extra parameters needed

--- a/client/ayon_houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_rop.py
@@ -28,7 +28,6 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "Redshift_ROP"})
         # Add chunk size attribute
         instance_data["chunkSize"] = 10

--- a/client/ayon_houdini/plugins/create/create_review.py
+++ b/client/ayon_houdini/plugins/create/create_review.py
@@ -27,7 +27,6 @@ class CreateReview(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "opengl"})
         instance_data["imageFormat"] = pre_create_data.get("imageFormat")
         instance_data["keepImages"] = pre_create_data.get("keepImages")

--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -16,7 +16,6 @@ class CreateUSD(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "usd"})
 
         instance = super(CreateUSD, self).create(

--- a/client/ayon_houdini/plugins/create/create_usd_look.py
+++ b/client/ayon_houdini/plugins/create/create_usd_look.py
@@ -19,7 +19,6 @@ class CreateUSDLook(plugin.HoudiniCreator):
 
     def create(self, product_name, instance_data, pre_create_data):
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "usd"})
 
         instance = super(CreateUSDLook, self).create(

--- a/client/ayon_houdini/plugins/create/create_usdrender.py
+++ b/client/ayon_houdini/plugins/create/create_usdrender.py
@@ -46,8 +46,6 @@ class CreateUSDRender(plugin.HoudiniCreator):
         # TODO: Support creation in /stage if wanted by user
         # pre_create_data["parent"] = "/stage"
 
-        # Remove the active, we are checking the bypass flag of the nodes
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "usdrender"})
 
         # Override default value for the Export Chunk Size because if the

--- a/client/ayon_houdini/plugins/create/create_vbd_cache.py
+++ b/client/ayon_houdini/plugins/create/create_vbd_cache.py
@@ -17,7 +17,6 @@ class CreateVDBCache(plugin.HoudiniCreator):
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "geometry"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())

--- a/client/ayon_houdini/plugins/create/create_vray_rop.py
+++ b/client/ayon_houdini/plugins/create/create_vray_rop.py
@@ -27,7 +27,6 @@ class CreateVrayROP(plugin.HoudiniCreator):
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
-        instance_data.pop("active", None)
         instance_data.update({"node_type": "vray_renderer"})
         # Add chunk size attribute
         instance_data["chunkSize"] = 10


### PR DESCRIPTION
## Changelog Description

Creators: Remove legacy `pop` of the 'active' data on create of instance.

## Additional info

This was a leftover from legacy creator where the active state was defined by the Bypass state of the node instead of a dedicated parm for the publisher.

⚠️ **Question:**

There also seems to be this [left-over Collect Active State plug-in](https://github.com/ynput/ayon-houdini/blob/a2285258185afb9db9337163204cb6b2e8b8f787/client/ayon_houdini/plugins/publish/collect_active_state.py#L27-L31). Which currently would be unable to activate any inactive instances as far as I know because new publisher would have those instances already deactivated from CreateContext. However, it will disable instances if the node were currently set to "bypass" but the instance was active in publisher. 

**Question:** Should we also remove the Collect Active State plug-in to avoid this unwanted side effect?

---

This fixes the default active state creation for https://github.com/ynput/ayon-core/pull/774 combined with https://github.com/ynput/ayon-houdini/pull/36

## Testing notes:

1. Creators should still work
2. The active state should be imprinted and collected the same way as before this PR.
3. Double check HDA creator and publishing works, because that one always has been special. :)