### PR TITLE
Houdini: Activate host color management by default

### DIFF
--- a/server/settings/imageio.py
+++ b/server/settings/imageio.py
@@ -96,7 +96,7 @@ class HoudiniImageIOModel(BaseSettingsModel):
 
 
 DEFAULT_IMAGEIO_SETTINGS = {
-    "activate_host_color_management": False,
+    "activate_host_color_management": True,
     "ocio_config": {
         "override_global_config": False,
         "filepath": []


### PR DESCRIPTION
## Changelog Description

Active Host Color Management for Houdini by default.

## Additional info

This value is only relevant if in ayon core you have Global Color Management enabled. However, Houdini was the only application that had an application specific `activate_host_color_management` defaulting to False - even though others all have it True.

This meant that by default if you enabled Global Color Management it would still remain disabled for Houdini unless this toggle was checked. That's straight up confusing.

This may need to come with a minor bump and clear statement in the release notes - because they may be edge cases where a studio can get bit by this if they relied on the previous disabled state but had Global Color Management enabled.

## Testing notes

1. New default value should work