### PR TITLE
Load Asset LOP: Add Help section

### DIFF
--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/Help
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/Help
@@ -1,0 +1,16 @@
+= AYON Load Asset =
+
+#icon: path/to/icon
+
+"""References a USD file, usually an asset."""
+
+== Overview ==
+
+*References* or *Payloads* a USD file into the current USD layer.
+
+In USD, when referencing, it's good to understand that you load a *single root prim* from the USD file. You will not get the full contents of the USD file if the USD file's content do not live within that single root primitive. By default, it will load a USD file's *default prim* but can be customized using the Load Options on this LOP node. 
+
+
+@related
+
+* [Node:lop/reference]


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Implement a HELP page for the Lop Node

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Pressing the question mark in Houdini on the node will now show help information about the AYON Load Asset LOP.

I'm not sure how to 'embed' the AYON icon for the help section. @MustafaJafar or @fabiaserra do you know maybe? Using e.g. `opdef:/ayon::Lop/lop_import::1.0?IconImage` didn't seem to work.

## Testing notes:

1. Create the node.
2. Press the question mark on the parameter window.

Here's an early screenshot:

![image](https://github.com/user-attachments/assets/07484e0f-421d-40b1-88c1-267708b86a76)
