### PR TITLE
Load Asset LOP: Make Set Project or Set Folder Path appear as pop-up dialog

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -446,7 +446,7 @@ class SelectFolderPathDialog(QtWidgets.QDialog):
 
         folder_widget = SimpleFoldersWidget(parent=self)
 
-        accept_button = QtWidgets.QPushButton("Accept")
+        accept_button = QtWidgets.QPushButton("Set folder path")
 
         main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.addWidget(project_widget, 0)
@@ -502,6 +502,8 @@ def select_folder_path(node):
     Args:
         node (hou.OpNode): The HDA node.
     """
+    cursor_pos = QtGui.QCursor.pos()
+
     main_window = lib.get_main_window()
 
     project_name = node.evalParm("project_name")
@@ -519,6 +521,12 @@ def select_folder_path(node):
         QtCore.QTimer.singleShot(100, _select_folder_path)
 
     dialog.setStyleSheet(load_stylesheet())
+
+    # Make it appear like a pop-up near cursor
+    dialog.resize(300, 600)
+    dialog.setWindowFlags(QtCore.Qt.Popup)
+    pos = dialog.mapToGlobal(cursor_pos - QtCore.QPoint(300, 0))
+    dialog.move(pos)
 
     result = dialog.exec_()
     if result != QtWidgets.QDialog.Accepted:


### PR DESCRIPTION
## Changelog Description

 Make Set Project or Set Folder Path appear as pop-up dialog similar to Set Product Name

## Additional info

![image](https://github.com/user-attachments/assets/2543a0a8-df7d-4f30-a72c-f39478374f31)

## Testing notes:

1. Load Asset LOP should work
2. The arrow button next to Project and Folder Path parm should work as intended and show a nice dialog at right location near the cursor
