### PR TITLE
Fix Collect USD Layers refactor and transfer `productGroup` to the extra product

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -114,7 +114,7 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
 
             project_name = context.data["projectName"]
             variant_base = instance.data["variant"]
-            subset = get_product_name(
+            product_name = get_product_name(
                 project_name=project_name,
                 # TODO: This should use task from `instance`
                 task_name=context.data["anatomyData"]["task"]["name"],
@@ -125,17 +125,20 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
                 project_settings=context.data["project_settings"]
             )
 
-            label = "{0} -> {1}".format(instance.data["name"], subset)
+            label = "{0} -> {1}".format(instance.data["name"], product_name)
             family = "usd"
             layer_inst.data["family"] = family
             layer_inst.data["families"] = [family]
-            layer_inst.data["subset"] = subset
+            layer_inst.data["productName"] = product_name
+            layer_inst.data["productType"] = instance.data["productType"]
             layer_inst.data["label"] = label
-            layer_inst.data["asset"] = instance.data["asset"]
+            layer_inst.data["folderPath"] = instance.data["folderPath"]
             layer_inst.data["task"] = instance.data.get("task")
             layer_inst.data["instance_node"] = instance.data["instance_node"]
             layer_inst.data["render"] = False
             layer_inst.data["output_node"] = creator_node
+            if instance.data.get("productGroup"):
+                layer_inst.data["productGroup"] = instance.data["productGroup"]
 
             # Inherit "use handles" from the source instance
             # TODO: Do we want to maybe copy full `publish_attributes` instead?


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

This fixes the Collect USD Layers logic where **Explicit layers** generated within the current solaris graph will turn into their own products.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

You'll need to have an "Explicit" layer in your solaris graph that will be saved along:

![image](https://github.com/user-attachments/assets/b3929a8c-88bb-4ace-ba85-07bc8a631a08)

## Testing notes:

1. Create a Solaris graph which generates an Explicit Save Layer as part of the graph.

E.g. this Sop Import generating a new 'layer' merged in:

![image](https://github.com/user-attachments/assets/720de8d7-7e8d-4a5b-a0a2-f479d16cf39d)

Note the **Layer Save Path** - it must be explicit otherwise Houdini's USD ROP node will error.

2. Publish USD
3. Should work with and without USD contribution workflow
