### PR TITLE
Set `force_valid_node_name` flag when creating placeholder nodes

### DIFF
--- a/client/ayon_houdini/api/workfile_template_builder.py
+++ b/client/ayon_houdini/api/workfile_template_builder.py
@@ -183,7 +183,8 @@ class HoudiniPlaceholderPlugin(PlaceholderPlugin):
         Feel free to override it in different workfile build plugins.
         """
  
-        node = hou.node("/out").createNode("null", node_name)
+        node = hou.node("/out").createNode(
+            "null", node_name, force_valid_node_name=True)
         node.moveToGoodPosition()
         parms = node.parmTemplateGroup()
         for parm in {"execute", "renderdialog"}:


### PR DESCRIPTION
## Changelog Description
Fix #60 


## Testing notes:

1. crate a placeholder while using a regex pattern not only a plain str.
