### PR TITLE
fix wrong name when calling `setName`

### DIFF
--- a/client/ayon_houdini/api/workfile_template_builder.py
+++ b/client/ayon_houdini/api/workfile_template_builder.py
@@ -231,6 +231,7 @@ class HoudiniPlaceholderPlugin(PlaceholderPlugin):
         
         # Update node name
         node_name = self.get_placeholder_node_name(placeholder_data)
+        node_name = hou.text.variableName(node_name)
         placeholder_node.setName(node_name, unique_name=True)
 
     def delete_placeholder(self, placeholder):


### PR DESCRIPTION
## Changelog Description
Follow up PR to https://github.com/ynput/ayon-houdini/pull/61 
as we missed to fix the name when updating the node names


## Testing notes:

1. update load placeholder, use a regex pattern not only a plain str.
