### PR TITLE
Render layer name collector

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -73,6 +73,9 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
             dynamic_data = {}
             if aov_name:
                 dynamic_data["aov"] = aov_name
+                
+            if instance.data.get("renderlayer"):
+                dynamic_data["renderlayer"] = instance.data["renderlayer"]
 
             product_name, product_group = get_product_name_and_group_from_template(
                 project_name=context.data["projectName"],

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -1,9 +1,10 @@
 import os
-
+import warnings
 import pyblish.api
 from ayon_core.pipeline.farm.patterning import match_aov_pattern
 from ayon_core.pipeline.farm.pyblish_functions import (
-    get_product_name_and_group_from_template
+    get_product_name_and_group_from_template,
+    _get_legacy_product_name_and_group
 )
 from ayon_core.pipeline.publish import (
     get_plugin_settings,
@@ -96,13 +97,10 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
             if instance.data.get("renderlayer"):
                 dynamic_data["renderlayer"] = instance.data["renderlayer"]
 
-            product_name, product_group = get_product_name_and_group_from_template(
-                project_name=context.data["projectName"],
-                task_entity=context.data["taskEntity"],
-                host_name=context.data["hostName"],
-                product_type=product_type,
-                variant=instance.data["productName"],
-                dynamic_data=dynamic_data,
+            product_name, product_group = self._get_product_name_and_group(
+                instance,
+                product_type,
+                dynamic_data
             )
 
             # Create instance for each AOV
@@ -171,3 +169,51 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
         # Skip integrating original render instance.
         # We are not removing it because it's used to trigger the render.
         instance.data["integrate"] = False
+
+    def _get_product_name_and_group(self, instance, product_type, dynamic_data):
+        """Get product name and group
+        
+        This method matches the logic in farm that gets
+         `product_name` and `group_name` respecting
+         `use_legacy_product_names_for_renders` logic in core settings.
+
+        Args:
+            instance (pyblish.api.Instance): The instance to publish.
+            product_type (str): Product type.
+            dynamic_data (dict): Dynamic data (camera, aov, ...)
+
+        Returns:
+            tuple (str, str): product name and group name
+
+        """
+
+        project_settings = instance.context.data.get("project_settings")
+
+        use_legacy_product_name = True
+        try:
+            use_legacy_product_name = project_settings["core"]["tools"]["creator"]["use_legacy_product_names_for_renders"]  # noqa: E501
+        except KeyError:
+            warnings.warn(
+                ("use_legacy_for_renders not found in project settings. "
+                 "Using legacy product name for renders. Please update "
+                 "your ayon-core version."), DeprecationWarning)
+            use_legacy_product_name = True
+
+        if use_legacy_product_name:
+            product_name, group_name = _get_legacy_product_name_and_group(
+                product_type=product_type,
+                source_product_name=instance.data["productName"],
+                task_name=instance.data["task"],
+                dynamic_data=dynamic_data)
+
+        else:
+            product_name, group_name = get_product_name_and_group_from_template(
+                project_name=instance.context.data["projectName"],
+                task_entity=instance.context.data["taskEntity"],
+                host_name=instance.context.data["hostName"],
+                product_type=product_type,
+                variant=instance.data["productName"],
+                dynamic_data=dynamic_data
+            )
+
+        return product_name, group_name

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -80,7 +80,7 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
                 host_name=context.data["hostName"],
                 product_type=product_type,
                 variant=instance.data["productName"],
-                dynamic_data = dynamic_data,
+                dynamic_data=dynamic_data,
             )
 
             # Create instance for each AOV

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -1,7 +1,6 @@
 import os
 
 import pyblish.api
-from ayon_core.pipeline.create import get_product_name
 from ayon_core.pipeline.farm.patterning import match_aov_pattern
 from ayon_core.pipeline.farm.pyblish_functions import (
     get_product_name_and_group_from_template

--- a/client/ayon_houdini/plugins/publish/collect_renderlayer.py
+++ b/client/ayon_houdini/plugins/publish/collect_renderlayer.py
@@ -14,7 +14,7 @@ from ayon_houdini.api import plugin
 
 class CollectRendelayerFromROP(plugin.HoudiniInstancePlugin):
     label = "Collect Render layer name from ROP"
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.499
     families = ["mantra_rop",
                 "karma_rop",
                 "redshift_rop",

--- a/client/ayon_houdini/plugins/publish/collect_renderlayer.py
+++ b/client/ayon_houdini/plugins/publish/collect_renderlayer.py
@@ -1,0 +1,27 @@
+"""Collect Render layer name from ROP.
+
+This simple collector will take name of the ROP node and set it as the render
+layer name for the instance.
+
+This aligns with the behavior of Maya and possibly others, even though there
+is nothing like render layer explicitly in Houdini.
+
+"""
+import hou
+import pyblish.api
+from ayon_houdini.api import plugin
+
+
+class CollectRendelayerFromROP(plugin.HoudiniInstancePlugin):
+    label = "Collect Render layer name from ROP"
+    order = pyblish.api.CollectorOrder
+    families = ["mantra_rop",
+                "karma_rop",
+                "redshift_rop",
+                "arnold_rop",
+                "vray_rop",
+                "usdrender"]
+
+    def process(self, instance):
+        rop = hou.node(instance.data.get("instance_node"))
+        instance.data["renderlayer"] = rop.name()

--- a/package.py
+++ b/package.py
@@ -5,6 +5,6 @@ version = "0.3.12-dev.1"
 client_dir = "ayon_houdini"
 
 ayon_required_addons = {
-    "core": ">0.4.1",
+    "core": ">=0.4.4",
 }
 ayon_compatible_addons = {}


### PR DESCRIPTION
## Changelog Description
This PR adds collector for render layer names - so they can be used later on in anatomy templates (either for publishing or delivery).

> [!WARNING]
Due to the dynamic nature of product templates it is difficult to determine good `group_name` from that. It should be basically `product_name` without **aov** data in it, but since the product name template might look like `{product[type]}<{Renderlayer}><_{Aov}>`, it is difficult to get it just from the resolved string.

## Additional info
> [!NOTE]
> To make use of the collected data, you need https://github.com/ynput/ayon-core/pull/841. This is continuation of https://github.com/ynput/ayon-core/pull/447

## Testing notes:

1. With mentioned ayon-core PR enable new behavior in the settings
2. Set render product name template correctly
3. Render something (locally and on farm)
