### PR TITLE
Collect required data for local and farm render jobs to have a 'colorspace' value specified

### DIFF
--- a/client/ayon_houdini/api/colorspace.py
+++ b/client/ayon_houdini/api/colorspace.py
@@ -1,59 +1,55 @@
+from typing import List
+
 import attr
 import hou
 from ayon_houdini.api.lib import get_color_management_preferences
-from ayon_core.pipeline.colorspace import get_display_view_colorspace_name
+from ayon_core.pipeline.colorspace import (
+    get_display_view_colorspace_name,
+    get_ocio_config_colorspaces
+)
+
 
 @attr.s
 class LayerMetadata(object):
     """Data class for Render Layer metadata."""
-    frameStart = attr.ib()
-    frameEnd = attr.ib()
+    products: "List[RenderProduct]" = attr.ib()
 
 
 @attr.s
 class RenderProduct(object):
-    """Getting Colorspace as
-    Specific Render Product Parameter for submitting
-    publish job.
-
-    """
+    """Specific Render Product Parameter for submitting."""
     colorspace = attr.ib()                      # colorspace
-    view = attr.ib()
     productName = attr.ib(default=None)
 
 
 class ARenderProduct(object):
-
-    def __init__(self):
-        """Constructor."""
-        # Initialize
-        self.layer_data = self._get_layer_data()
-        self.layer_data.products = self.get_colorspace_data()
-
-    def _get_layer_data(self):
-        return LayerMetadata(
-            frameStart=int(hou.playbar.frameRange()[0]),
-            frameEnd=int(hou.playbar.frameRange()[1]),
-        )
-
-    def get_colorspace_data(self):
-        """To be implemented by renderer class.
-
-        This should return a list of RenderProducts.
-
-        Returns:
-            list: List of RenderProduct
-
-        """
-        data = get_color_management_preferences()
-        colorspace_data = [
-            RenderProduct(
-                colorspace=data["display"],
-                view=data["view"],
-                productName=""
-            )
+    """This is the minimal data structure required to get
+    `ayon_core.pipeline.farm.pyblish_functions.create_instances_for_aov` to
+    work with deadline addon's job submissions."""
+    # TODO: The exact data structure should actually be defined in core for all
+    #  addons to align.
+    def __init__(self, aov_names: List[str]):
+        colorspace = get_scene_linear_colorspace()
+        products = [
+            RenderProduct(colorspace=colorspace, productName=aov_name)
+            for aov_name in aov_names
         ]
-        return colorspace_data
+        self.layer_data = LayerMetadata(products=products)
+
+
+def get_scene_linear_colorspace():
+    """Return colorspace name for Houdini's OCIO config scene linear role.
+
+    By default, renderers in Houdini render output images in the scene linear
+    role colorspace.
+
+    Returns:
+        Optional[str]: The colorspace name for the 'scene_linear' role in
+            the OCIO config Houdini is currently set to.
+    """
+    ocio_config_path = hou.Color.ocio_configPath()
+    colorspaces = get_ocio_config_colorspaces(ocio_config_path)
+    return colorspaces["roles"].get("scene_linear", {}).get("colorspace")
 
 
 def get_default_display_view_colorspace():

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -594,7 +594,15 @@ def get_color_management_preferences():
         log.debug(
             "Houdini `hou.Color.ocio_defaultView()` returned empty value."
             " Falling back to `PyOpenColorIO` to get the default view.")
-        import PyOpenColorIO
+        try:
+            import PyOpenColorIO
+        except ImportError:
+            log.warning(
+                "Unable to workaround empty return value of "
+                "`hou.Color.ocio_defaultView()` because `PyOpenColorIO` is "
+                "not available.")
+            return preferences
+
         config_path = preferences["config"]
         config = PyOpenColorIO.Config.CreateFromFile(config_path)
         display = config.getDefaultDisplay()

--- a/client/ayon_houdini/plugins/publish/collect_arnold_rop.py
+++ b/client/ayon_houdini/plugins/publish/collect_arnold_rop.py
@@ -4,11 +4,8 @@ import re
 import hou
 import pyblish.api
 
-from ayon_houdini.api import colorspace, plugin
-from ayon_houdini.api.lib import (
-    get_color_management_preferences,
-    evalParmNoFrame
-)
+from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import evalParmNoFrame
 
 
 class CollectArnoldROPRenderProducts(plugin.HoudiniInstancePlugin):
@@ -100,7 +97,6 @@ class CollectArnoldROPRenderProducts(plugin.HoudiniInstancePlugin):
             self.log.debug("Found render product: {}".format(product))
 
         instance.data["files"] = list(render_products)
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         # For now by default do NOT try to publish the rendered output
         instance.data["publishJobState"] = "Suspended"
@@ -109,12 +105,6 @@ class CollectArnoldROPRenderProducts(plugin.HoudiniInstancePlugin):
         if "expectedFiles" not in instance.data:
             instance.data["expectedFiles"] = list()
         instance.data["expectedFiles"].append(files_by_aov)
-
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
 
     def get_render_product_name(self, prefix, suffix):
         """Return the output filename using the AOV prefix and suffix"""

--- a/client/ayon_houdini/plugins/publish/collect_karma_rop.py
+++ b/client/ayon_houdini/plugins/publish/collect_karma_rop.py
@@ -4,14 +4,8 @@ import os
 import hou
 import pyblish.api
 
-from ayon_houdini.api.lib import (
-    evalParmNoFrame,
-    get_color_management_preferences
-)
-from ayon_houdini.api import (
-    colorspace,
-    plugin
-)
+from ayon_houdini.api.lib import evalParmNoFrame
+from ayon_houdini.api import plugin
 
 
 class CollectKarmaROPRenderProducts(plugin.HoudiniInstancePlugin):
@@ -63,7 +57,6 @@ class CollectKarmaROPRenderProducts(plugin.HoudiniInstancePlugin):
 
         filenames = list(render_products)
         instance.data["files"] = filenames
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         for product in render_products:
             self.log.debug("Found render product: %s" % product)
@@ -71,12 +64,6 @@ class CollectKarmaROPRenderProducts(plugin.HoudiniInstancePlugin):
         if "expectedFiles" not in instance.data:
             instance.data["expectedFiles"] = list()
         instance.data["expectedFiles"].append(files_by_aov)
-
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
 
     def get_render_product_name(self, prefix, suffix):
         product_name = prefix

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -4,12 +4,15 @@ from ayon_core.pipeline.create import get_product_name
 from ayon_core.pipeline.farm.patterning import match_aov_pattern
 from ayon_core.pipeline.publish import (
     get_plugin_settings,
-    apply_plugin_settings_automatically
+    apply_plugin_settings_automatically,
+    ColormanagedPyblishPluginMixin
 )
 from ayon_houdini.api import plugin
+from ayon_houdini.api.colorspace import get_scene_linear_colorspace
 
 
-class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
+class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
+                                  ColormanagedPyblishPluginMixin):
     """Collect instances for local render.
 
     Agnostic Local Render Collector.
@@ -49,9 +52,9 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
             # get aov_filter from deadline settings
             cls.aov_filter = project_settings["deadline"]["publish"]["ProcessSubmittedJobOnFarm"]["aov_filter"]
             cls.aov_filter = {
-            item["name"]: item["value"]
-            for item in cls.aov_filter
-        }
+                item["name"]: item["value"]
+                for item in cls.aov_filter
+            }
 
     def process(self, instance):
 
@@ -74,6 +77,14 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
             instance.data["productName"]
         )
 
+        # NOTE: The assumption that the output image's colorspace is the
+        #   scene linear role may be incorrect. Certain renderers, like
+        #   Karma allow overriding explicitly the output colorspace of the
+        #   image. Such override are currently not considered since these
+        #   would need to be detected in a renderer-specific way and the
+        #   majority of production scenarios these would not be overridden.
+        # TODO: Support renderer-specific explicit colorspace overrides
+        colorspace = get_scene_linear_colorspace()
         for aov_name, aov_filepaths in expectedFiles.items():
             product_name = product_group
 
@@ -108,6 +119,21 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
             if len(aov_filenames) == 1:
                 aov_filenames = aov_filenames[0]
 
+            representation = {
+                "stagingDir": staging_dir,
+                "ext": ext,
+                "name": ext,
+                "tags": ["review"] if preview else [],
+                "files": aov_filenames,
+                "frameStart": instance.data["frameStartHandle"],
+                "frameEnd": instance.data["frameEndHandle"]
+            }
+
+            # Set the colorspace for the representation
+            self.set_representation_colorspace(representation,
+                                               context,
+                                               colorspace=colorspace)
+
             aov_instance.data.update({
                 # 'label': label,
                 "task": instance.data["task"],
@@ -120,17 +146,7 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin):
                 "productGroup": product_group,
                 "families": ["render.local.hou", "review"],
                 "instance_node": instance.data["instance_node"],
-                "representations": [
-                    {
-                        "stagingDir": staging_dir,
-                        "ext": ext,
-                        "name": ext,
-                        "tags": ["review"] if preview else [],
-                        "files": aov_filenames,
-                        "frameStart": instance.data["frameStartHandle"],
-                        "frameEnd": instance.data["frameEndHandle"]
-                    }
-                ]
+                "representations": [representation]
             })
 
         # Skip integrating original render instance.

--- a/client/ayon_houdini/plugins/publish/collect_mantra_rop.py
+++ b/client/ayon_houdini/plugins/publish/collect_mantra_rop.py
@@ -4,14 +4,8 @@ import os
 import hou
 import pyblish.api
 
-from ayon_houdini.api.lib import (
-    evalParmNoFrame,
-    get_color_management_preferences
-)
-from ayon_houdini.api import (
-    colorspace,
-    plugin
-)
+from ayon_houdini.api.lib import evalParmNoFrame
+from ayon_houdini.api import plugin
 
 
 class CollectMantraROPRenderProducts(plugin.HoudiniInstancePlugin):
@@ -108,7 +102,6 @@ class CollectMantraROPRenderProducts(plugin.HoudiniInstancePlugin):
 
         filenames = list(render_products)
         instance.data["files"] = filenames
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         # For now by default do NOT try to publish the rendered output
         instance.data["publishJobState"] = "Suspended"
@@ -117,12 +110,6 @@ class CollectMantraROPRenderProducts(plugin.HoudiniInstancePlugin):
         if "expectedFiles" not in instance.data:
             instance.data["expectedFiles"] = list()
         instance.data["expectedFiles"].append(files_by_aov)
-
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
 
     def get_render_product_name(self, prefix, suffix):
         product_name = prefix

--- a/client/ayon_houdini/plugins/publish/collect_redshift_rop.py
+++ b/client/ayon_houdini/plugins/publish/collect_redshift_rop.py
@@ -4,14 +4,8 @@ import os
 import hou
 import pyblish.api
 
-from ayon_houdini.api.lib import (
-    evalParmNoFrame,
-    get_color_management_preferences
-)
-from ayon_houdini.api import (
-    colorspace,
-    plugin
-)
+from ayon_houdini.api.lib import evalParmNoFrame
+from ayon_houdini.api import plugin
 
 
 class CollectRedshiftROPRenderProducts(plugin.HoudiniInstancePlugin):
@@ -119,7 +113,6 @@ class CollectRedshiftROPRenderProducts(plugin.HoudiniInstancePlugin):
 
         filenames = list(render_products)
         instance.data["files"] = filenames
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         # For now by default do NOT try to publish the rendered output
         instance.data["publishJobState"] = "Suspended"
@@ -128,12 +121,6 @@ class CollectRedshiftROPRenderProducts(plugin.HoudiniInstancePlugin):
         if "expectedFiles" not in instance.data:
             instance.data["expectedFiles"] = []
         instance.data["expectedFiles"].append(files_by_aov)
-
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
 
     def get_render_product_name(self, prefix, suffix):
         """Return the output filename using the AOV prefix and suffix"""

--- a/client/ayon_houdini/plugins/publish/collect_render_colorspace.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_colorspace.py
@@ -1,0 +1,41 @@
+from ayon_houdini.api import plugin, colorspace
+
+import pyblish.api
+
+
+class CollectHoudiniRenderColorspace(plugin.HoudiniInstancePlugin):
+    """Collect Colorspace data for render output images.
+
+    This currently assumes that all render products are in 'scene_linear'
+    colorspace role - which is the default behavior for renderers in Houdini.
+    """
+
+    label = "Collect Render Colorspace"
+    order = pyblish.api.CollectorOrder + 0.15
+    families = ["mantra_rop",
+                "karma_rop",
+                "redshift_rop",
+                "arnold_rop",
+                "vray_rop",
+                "usdrender"]
+
+    def process(self, instance):
+        # Set the required data for `ayon_core.pipeline.farm.pyblish_functions`
+        # functions used for farm publish job processing.
+
+        # Define render products for `create_instances_for_aov`
+        # which uses it in `_create_instances_for_aov()` to match the render
+        # product's name to aovs to define the colorspace.
+        expected_files = instance.data["expectedFiles"]
+        aov_name = list(expected_files[0].keys())
+        render_products_data = colorspace.ARenderProduct(aov_name)
+        instance.data["renderProducts"] = render_products_data
+
+        # Required data for `create_instances_for_aov`
+        colorspace_data = colorspace.get_color_management_preferences()
+        instance.data["colorspaceConfig"] = colorspace_data["config"]
+        instance.data["colorspaceDisplay"] = colorspace_data["display"]
+        instance.data["colorspaceView"] = colorspace_data["view"]
+
+        # Used in `create_skeleton_instance()`
+        instance.data["colorspace"] = colorspace.get_scene_linear_colorspace()

--- a/client/ayon_houdini/plugins/publish/collect_usd_render.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_render.py
@@ -4,14 +4,8 @@ import re
 import hou
 import pyblish.api
 
-from ayon_houdini.api import (
-    colorspace,
-    plugin
-)
-from ayon_houdini.api.lib import (
-    evalParmNoFrame,
-    get_color_management_preferences
-)
+from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import evalParmNoFrame
 
 
 class CollectUsdRender(plugin.HoudiniInstancePlugin):
@@ -23,9 +17,6 @@ class CollectUsdRender(plugin.HoudiniInstancePlugin):
 
     Provides:
         instance    -> ifdFile
-        instance    -> colorspaceConfig
-        instance    -> colorspaceDisplay
-        instance    -> colorspaceView
 
     """
 
@@ -75,12 +66,5 @@ class CollectUsdRender(plugin.HoudiniInstancePlugin):
             if "$F" not in export_file:
                 instance.data["splitRenderFrameDependent"] = False
 
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
-
         # stub required data for Submit Publish Job publish plug-in
         instance.data["attachTo"] = []
-        instance.data["renderProducts"] = colorspace.ARenderProduct()

--- a/client/ayon_houdini/plugins/publish/collect_vray_rop.py
+++ b/client/ayon_houdini/plugins/publish/collect_vray_rop.py
@@ -4,14 +4,8 @@ import os
 import hou
 import pyblish.api
 
-from ayon_houdini.api.lib import (
-    evalParmNoFrame,
-    get_color_management_preferences
-)
-from ayon_houdini.api import (
-    colorspace,
-    plugin
-)
+from ayon_houdini.api.lib import evalParmNoFrame
+from ayon_houdini.api import plugin
 
 
 class CollectVrayROPRenderProducts(plugin.HoudiniInstancePlugin):
@@ -89,7 +83,6 @@ class CollectVrayROPRenderProducts(plugin.HoudiniInstancePlugin):
             self.log.debug("Found render product: %s" % product)
         filenames = list(render_products)
         instance.data["files"] = filenames
-        instance.data["renderProducts"] = colorspace.ARenderProduct()
 
         # For now by default do NOT try to publish the rendered output
         instance.data["publishJobState"] = "Suspended"
@@ -99,12 +92,6 @@ class CollectVrayROPRenderProducts(plugin.HoudiniInstancePlugin):
             instance.data["expectedFiles"] = list()
         instance.data["expectedFiles"].append(files_by_aov)
         self.log.debug("expectedFiles:{}".format(files_by_aov))
-
-        # update the colorspace data
-        colorspace_data = get_color_management_preferences()
-        instance.data["colorspaceConfig"] = colorspace_data["config"]
-        instance.data["colorspaceDisplay"] = colorspace_data["display"]
-        instance.data["colorspaceView"] = colorspace_data["view"]
 
     def get_render_product_name(self, prefix, suffix="<reName>"):
         """Return the beauty output filename if render element enabled


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

This makes it so that for all render products generated from Houdini renderers and their render instances the colorspace is set to that of the `scene_linear` OCIO role in the currently set OCIO config.

By doing so, the transcoding plug-in is capable of using this as the _source_ colorspace when needing to transcode from a source colorspace to a destination colorspace.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Without this it'd mean that the transcoding would basically get ignored because it would not know about the source colorspace of the output image. It would get ignored [here](https://github.com/ynput/ayon-core/blob/c17f53d89dfd9bd7d681b1f5d81287b8959e720f/client/ayon_core/plugins/publish/extract_color_transcode.py#L338-L341).

The logic involved with this definitely shows we have some API refactoring to do in `ayon_core` to make this much easier to access and do. For now I've tried to add in comments in the code here what instance data is being set and why for the farm instances. But `ayon_core.pipeline.farm.pyblish_functions` can definitely use some cleanup/restructuring to simplify things.

## Testing notes:

_Global color management should be enabled in core!_ (However, it may be good to do also do at least a test run with one of the renderers with global color management disabled to ensure we're not breaking that.)

1. Local and farm render submissions should work from Houdini for the different renderers:
    - [ ] Karma ROP
    - [ ] Mantra ROP
    - [ ] V-Ray ROP
    - [ ] Arnold ROP
    - [ ] Redshift ROP
    - [ ] USDrender (with any of the above renderers)
2. The transcoding plug-in should kick in according to `ayon+settings://core/publish/ExtractOIIOTranscode` profiles. Note that if you have no matching profiles it would of course still not transcode.
3. The output image (reviewable) should have matching colors according to the transcoding profile's expectations. E.g. when using Houdini's display/view settings the colors should match as close as possible (1:1, but keeping in account any encoding color shifts).