### PR TITLE
Local render AOVs review frameStartHandle and frameEndHandle fix

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -133,11 +133,10 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
             self.set_representation_colorspace(representation,
                                                context,
                                                colorspace=colorspace)
-            
-            if instance.data['review']:
-                families= ["render.local.hou", "review"]
-            else:
-                families= ["render.local.hou"]
+
+            families = ["render.local.hou"]
+            if instance.data.get('review'):
+                families.append("review")
 
             aov_instance.data.update({
                 # 'label': label,

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -144,15 +144,15 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
                 "folderPath": instance.data["folderPath"],
                 "frameStart": instance.data["frameStartHandle"],
                 "frameEnd": instance.data["frameEndHandle"],
+                "frameStartHandle": instance.data["frameStartHandle"],
+                "frameEndHandle": instance.data["frameEndHandle"],
                 "productType": product_type,
                 "family": product_type,
                 "productName": product_name,
                 "productGroup": product_group,
                 "families": families,
                 "instance_node": instance.data["instance_node"],
-                "representations": [representation],
-                "frameStartHandle": instance.data["frameStartHandle"],
-                "frameEndHandle": instance.data["frameEndHandle"]
+                "representations": [representation]
             })
 
         # Skip integrating original render instance.

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -146,7 +146,9 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
                 "productGroup": product_group,
                 "families": ["render.local.hou", "review"],
                 "instance_node": instance.data["instance_node"],
-                "representations": [representation]
+                "representations": [representation],
+                "frameStartHandle": instance.data["frameStartHandle"],
+                "frameEndHandle": instance.data["frameEndHandle"]
             })
 
         # Skip integrating original render instance.

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -133,6 +133,11 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
             self.set_representation_colorspace(representation,
                                                context,
                                                colorspace=colorspace)
+            
+            if instance.data['review']:
+                families= ["render.local.hou", "review"]
+            else:
+                families= ["render.local.hou"]
 
             aov_instance.data.update({
                 # 'label': label,
@@ -144,7 +149,7 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
                 "family": product_type,
                 "productName": product_name,
                 "productGroup": product_group,
-                "families": ["render.local.hou", "review"],
+                "families": families,
                 "instance_node": instance.data["instance_node"],
                 "representations": [representation],
                 "frameStartHandle": instance.data["frameStartHandle"],
@@ -154,3 +159,5 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
         # Skip integrating original render instance.
         # We are not removing it because it's used to trigger the render.
         instance.data["integrate"] = False
+        self.log.debug( aov_instance.data)
+        #self.log.debug( instance.data)

--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -159,5 +159,3 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
         # Skip integrating original render instance.
         # We are not removing it because it's used to trigger the render.
         instance.data["integrate"] = False
-        self.log.debug( aov_instance.data)
-        #self.log.debug( instance.data)


### PR DESCRIPTION
## Changelog Description
when we create new instances for each aov code forgets to add frameStartHadnle and frame EndHandle for new instance so new representation will not publish 


## Additional info
My setup was houdini+redhift+animated focal lenght so code fail here
![image](https://github.com/user-attachments/assets/4a7b9ca3-e46c-4c4a-a7f4-d5f80ae49e97)



## Testing notes:

1) try creating project with animated focal lenght
2) try to publish
3) see error
![image](https://github.com/user-attachments/assets/dba99e1a-f3f7-4d05-b755-3217da4f84ef)



It turns out that code dont parse frameStartHadnle and frame EndHandle data to newly created per aov instance so code fails