### PR TITLE
Fix USD OutputProcessor errors on USD export in Houdini 20.5+

### DIFF
--- a/client/ayon_houdini/startup/husdplugins/outputprocessors/remap_to_publish.py
+++ b/client/ayon_houdini/startup/husdplugins/outputprocessors/remap_to_publish.py
@@ -5,6 +5,9 @@ import hou
 from husd.outputprocessor import OutputProcessor
 
 
+_COMPATIBILITY_PLACEHOLDER = object()
+
+
 class AYONRemapPaths(OutputProcessor):
     """Remap paths based on a mapping dict on rop node."""
 
@@ -38,11 +41,18 @@ class AYONRemapPaths(OutputProcessor):
 
         return group.asDialogScript()
 
-    def beginSave(self, config_node, config_overrides, lop_node, t):
-        super(AYONRemapPaths, self).beginSave(config_node,
-                                              config_overrides,
-                                              lop_node,
-                                              t)
+    def beginSave(self,
+                  config_node,
+                  config_overrides,
+                  lop_node,
+                  t,
+                  # Added in Houdini 20.5.182
+                  stage_variables=_COMPATIBILITY_PLACEHOLDER):
+
+        args = [config_node, config_overrides, lop_node, t]
+        if stage_variables is not _COMPATIBILITY_PLACEHOLDER:
+            args.append(stage_variables)
+        super(AYONRemapPaths, self).beginSave(*args)
 
         value = config_node.evalParm("ayon_remap_paths_remap_json")
         mapping = json.loads(value)


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Fix `beginSave` arguments for Houdini 20.5.182+ with added `stage_variables` argument to `OutputProcessor.beginSave` method

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

Fixes #53

I tested in Houdini 20.5.278 and 20.0.724; worked for me in both.

## Testing notes:

1. Publish a USD instance from Houdini
2. No error pop-up should show in Houdini 20.5+ (nor should an error occur in older versions)