### PR TITLE
USD ROP allow remapping explicit layer save paths to be remapped to AYON Entity URI

### DIFF
--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -18,7 +18,7 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
     label = "Extract USD"
     families = ["usdrop"]
 
-    use_ayon_entity_uri = True
+    use_ayon_entity_uri = False
 
     def process(self, instance):
 

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -3,11 +3,11 @@ from typing import List, AnyStr
 
 import pyblish.api
 
+from ayon_core.pipeline.entity_uri import construct_ayon_entity_uri
 from ayon_core.pipeline.publish.lib import get_instance_expected_output_path
 from ayon_houdini.api import plugin
 from ayon_houdini.api.lib import render_rop
 from ayon_houdini.api.usd import remap_paths
-from ayon_core.pipeline.entity_uri import construct_ayon_entity_uri
 
 import hou
 

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -3,19 +3,25 @@ from typing import List, AnyStr
 
 import pyblish.api
 
+from ayon_core.lib import BoolDef
+from ayon_core.pipeline import AYONPyblishPluginMixin
 from ayon_core.pipeline.publish.lib import get_instance_expected_output_path
 from ayon_houdini.api import plugin
 from ayon_houdini.api.lib import render_rop
 from ayon_houdini.api.usd import remap_paths
+from ayon_core.pipeline.entity_uri import construct_ayon_entity_uri
 
 import hou
 
 
-class ExtractUSD(plugin.HoudiniExtractorPlugin):
+class ExtractUSD(plugin.HoudiniExtractorPlugin, AYONPyblishPluginMixin):
 
     order = pyblish.api.ExtractorOrder
     label = "Extract USD"
     families = ["usdrop"]
+
+    use_ayon_entity_uri = False
+    use_ayon_entity_uri_optional = True
 
     def process(self, instance):
 
@@ -29,7 +35,11 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
 
         self.log.info("Writing USD '%s' to '%s'" % (file_name, staging_dir))
 
-        mapping = self.get_source_to_publish_paths(instance.context)
+        attr_values = self.get_attr_values_from_data(instance.data)
+        use_ayon_entity_uri: bool = attr_values.get(
+            "use_ayon_entity_uri", self.use_ayon_entity_uri)
+        mapping = self.get_source_to_publish_paths(
+            instance.context, use_ayon_entity_uri)
 
         # Allow instance-specific path remapping overrides, e.g. changing
         # paths on used resources/textures for looks
@@ -55,10 +65,22 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
         }
         instance.data["representations"].append(representation)
 
-    def get_source_to_publish_paths(self, context):
+    def get_source_to_publish_paths(self,
+                                    context,
+                                    use_ayon_entity_uri):
         """Define a mapping of all current instances in context from source
         file to publish file so this can be used on the USD save to remap
-        asset layer paths on publish via AyonRemapPaths output processor"""
+        asset layer paths on publish via AyonRemapPaths output processor
+
+        Arguments:
+            context (pyblish.api.Context): Publish context.
+            use_ayon_entity_uri (bool): Whether to remap to AYON Entity URI
+                or to a resolved publish filepath.
+
+        Returns:
+            dict[str, str]: Mapping from source path to remapped path.
+
+        """
 
         mapping = {}
         for instance in context:
@@ -76,14 +98,46 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
                 #   asset paths that are set use e.g. $F
                 # TODO: If the representation has multiple files we might need
                 #   to define the path remapping per file of the sequence
-                path = get_instance_expected_output_path(
-                    instance, representation_name=name, ext=ext
-                )
+                if use_ayon_entity_uri:
+                    # Construct AYON entity URI
+                    # Note: entity does not exist yet
+                    path = construct_ayon_entity_uri(
+                        project_name=context.data["projectName"],
+                        folder_path=instance.data["folderPath"],
+                        product=instance.data["productName"],
+                        version=instance.data["version"],
+                        representation_name=name
+                    )
+                else:
+                    # Resolved publish filepath
+                    path = get_instance_expected_output_path(
+                        instance, representation_name=name, ext=ext
+                    )
+
                 for source_path in get_source_paths(instance, repre):
                     source_path = os.path.normpath(source_path)
                     mapping[source_path] = path
 
         return mapping
+
+    @classmethod
+    def get_attribute_defs(cls):
+
+        attributes = []
+        if cls.use_ayon_entity_uri_optional:
+            attributes.append(
+                BoolDef(
+                    "use_ayon_entity_uri",
+                    label="Use AYON Entity URI",
+                    tooltip=(
+                        "Remap explicit save layers to AYON Entity URI on "
+                        "publish instead of the resolved publish filepaths."
+                    ),
+                    default=cls.use_ayon_entity_uri
+                )
+            )
+
+        return attributes
 
 
 def get_source_paths(

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -33,6 +33,8 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
         self.log.info("Writing USD '%s' to '%s'" % (file_name, staging_dir))
 
         mapping = self.get_source_to_publish_paths(instance.context)
+        if mapping:
+            self.log.debug(f"Remapping paths: {mapping}")
 
         # Allow instance-specific path remapping overrides, e.g. changing
         # paths on used resources/textures for looks

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -106,14 +106,6 @@ class ExtractUsdModel(BaseSettingsModel):
             "instead of the resolved publish filepaths."
         )
     )
-    use_ayon_entity_uri_optional: bool = SettingsField(
-        True,
-        title="Make remap save layers to AYON Entity URI optional",
-        description=(
-            "When optional a toggle for 'Use AYON Entity URI' will be "
-            "available for the instance in the publisher UI."
-        )
-    )
 
 
 class PublishPluginsModel(BaseSettingsModel):

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -97,6 +97,25 @@ class BasicEnabledStatesModel(BaseSettingsModel):
     active: bool = SettingsField(title="Active")
 
 
+class ExtractUsdModel(BaseSettingsModel):
+    use_ayon_entity_uri: bool = SettingsField(
+        False,
+        title="Remap save layers to AYON Entity URI",
+        description=(
+            "Remap explicit save layers to AYON Entity URI on publish "
+            "instead of the resolved publish filepaths."
+        )
+    )
+    use_ayon_entity_uri_optional: bool = SettingsField(
+        True,
+        title="Make remap save layers to AYON Entity URI optional",
+        description=(
+            "When optional a toggle for 'Use AYON Entity URI' will be "
+            "available for the instance in the publisher UI."
+        )
+    )
+
+
 class PublishPluginsModel(BaseSettingsModel):
     CollectAssetHandles: CollectAssetHandlesModel = SettingsField(
         default_factory=CollectAssetHandlesModel,
@@ -142,6 +161,10 @@ class PublishPluginsModel(BaseSettingsModel):
         title="Extract Active View Thumbnail",
         section="Extractors"
     )
+    ExtractUSD: ExtractUsdModel = SettingsField(
+        default_factory=ExtractUsdModel,
+        title="Extract USD"
+    )
 
 
 DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
@@ -157,7 +180,7 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
         "enabled": False,
         "optional": True,
         "active": True,
-        "families" : []
+        "families": []
     },
     "CollectLocalRenderInstances": {
         "use_deadline_aov_filter": False,
@@ -214,5 +237,8 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
         "enabled": True,
         "optional": False,
         "active": True
+    },
+    "ExtractUSD": {
+        "use_ayon_entity_uri": False
     }
 }


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Allow remapping to AYON Entity URI instead of resolved publish filepath for layer save paths directly written out from the USD ROP that also turn into their own publishable instance.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->


## Testing notes:

Enable `Extract USD` attribute `use_ayon_entity_uri` in settings.

1. Create a Solaris stage that generates an additional layer save path (explicit layer save path)
2. This layer save path will introduce an additional publish instance.
3. With the setting enabled that instance should be remapped to an AYON Entity URI
4. With the setting disabled that instance should be remapped to the resolved publish path (same as before this PR)

*When using _Merge LOP_ to merge multiple explicit layer save paths (e.g. separate SOP imports with explicit layer save paths) keep in mind that Merge LOP default merge mode "Simple merge" will discard them. More details, see [here](https://github.com/ynput/ayon-houdini/pull/80#issuecomment-2362864108)