### PR TITLE
Collect current file ignore the default untitled scene when no save or load has happened yet

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_current_file.py
+++ b/client/ayon_houdini/plugins/publish/collect_current_file.py
@@ -22,18 +22,8 @@ class CollectHoudiniCurrentFile(plugin.HoudiniContextPlugin):
             # By default, Houdini will even point a new scene to a path.
             # However if the file is not saved at all and does not exist,
             # we assume the user never set it.
+            self.log.warning("Houdini workfile is unsaved.")
             current_file = ""
-        else:
-            # Due to even a new file being called 'untitled.hip' we are unable
-            # to confirm the current scene was ever saved because the file
-            # could have existed already. We will allow it if the file exists,
-            # but show a warning for this edge case to clarify the potential
-            # false positive.
-            self.log.warning(
-                "Current file is 'untitled.hip' and we are "
-                "unable to detect whether the current scene is "
-                "saved correctly."
-            )
 
         context.data["currentFile"] = current_file
         self.log.info('Current workfile path: {}'.format(current_file))

--- a/client/ayon_houdini/plugins/publish/collect_current_file.py
+++ b/client/ayon_houdini/plugins/publish/collect_current_file.py
@@ -15,13 +15,15 @@ class CollectHoudiniCurrentFile(plugin.HoudiniContextPlugin):
         """Inject the current working file"""
 
         current_file = hou.hipFile.path()
-        if not os.path.exists(current_file):
+        if (
+                hou.hipFile.isNewFile()
+                or not os.path.exists(current_file)
+        ):
             # By default, Houdini will even point a new scene to a path.
             # However if the file is not saved at all and does not exist,
             # we assume the user never set it.
             current_file = ""
-
-        elif os.path.basename(current_file) == "untitled.hip":
+        else:
             # Due to even a new file being called 'untitled.hip' we are unable
             # to confirm the current scene was ever saved because the file
             # could have existed already. We will allow it if the file exists,


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Never allow the "new" file (the standard scene) to be collected as current file

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

This is a companion PR to https://github.com/ynput/ayon-core/pull/786
When used together a better error report is shown for unsaved files.

![image](https://github.com/user-attachments/assets/0960fe14-b439-4b44-9f30-5832d03767d0)

(Screenshots from Houdini)

## Testing notes:

1. Use this PR together with https://github.com/ynput/ayon-core/pull/786
2. Try publishing from an unsaved workfile
3. Restart houdini (allow it to open last workfile) - it should correctly detect that you have a scene file open now
