### PR TITLE
Loader: Fix missing `filepath_from_context` classmethod decorator

### DIFF
--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -319,6 +319,7 @@ class HoudiniLoader(load.LoaderPlugin):
     settings_category = SETTINGS_CATEGORY
     use_ayon_entity_uri = False
 
+    @classmethod
     def filepath_from_context(cls, context):
         if cls.use_ayon_entity_uri:
             return get_ayon_entity_uri_from_representation_context(context)


### PR DESCRIPTION
## Changelog Description
<!-- Paragraphs contain detailed information on the changes made to the product or service, providing an in-depth description of the updates and enhancements. They can be used to explain the reasoning behind the changes, or to highlight the importance of the new features. Paragraphs can often include links to further information or support documentation. -->

Fix missing `filepath_from_context` classmethod decorator that it should match from the parent class.

## Additional info
<!-- Paragraphs of text giving context of additional technical information or code examples. -->

My bad in this PR: https://github.com/ynput/ayon-houdini/pull/26 - I missed it there.

## Testing notes:

1. Validate loaders work.
2. Or just compare it against the parent class.
