### PR TITLE
Load filepath to node: Use <UDIM> token

### DIFF
--- a/client/ayon_houdini/plugins/load/load_filepath.py
+++ b/client/ayon_houdini/plugins/load/load_filepath.py
@@ -134,7 +134,7 @@ class FilePathLoader(plugin.HoudiniLoader):
 
             project_name: str = context["project"]["name"]
             anatomy = Anatomy(project_name)
-            context["roots"] = anatomy.roots
+            context["root"] = anatomy.roots
             path = StringTemplate(template).format(context)
 
         return os.path.normpath(path).replace("\\", "/")

--- a/client/ayon_houdini/plugins/load/load_filepath.py
+++ b/client/ayon_houdini/plugins/load/load_filepath.py
@@ -16,11 +16,11 @@ def remove_format_spec(template: str, key: str) -> str:
     For example, change `{frame:0>4d}` into `{frame}`
 
     Examples:
-        >>> remove_format_spec_for_keys("{frame:0>4d}", "frame")
+        >>> remove_format_spec("{frame:0>4d}", "frame")
         '{frame}'
-        >>> remove_format_spec_for_keys("{digit:04d}/{frame:0>4d}", "frame")
+        >>> remove_format_spec("{digit:04d}/{frame:0>4d}", "frame")
         '{digit:04d}/{udim}_{frame}'
-        >>> remove_format_spec_for_keys("{a: >4}/{aa: >4}", "a")
+        >>> remove_format_spec("{a: >4}/{aa: >4}", "a")
         '{a}/{aa: >4}'
 
     """

--- a/client/ayon_houdini/plugins/load/load_filepath.py
+++ b/client/ayon_houdini/plugins/load/load_filepath.py
@@ -124,7 +124,7 @@ class FilePathLoader(plugin.HoudiniLoader):
                 repre_context["frame"] = "$F{}".format(len(frame))   # e.g. $F4
 
             project_name: str = repre_context["project"]["name"]
-            anatomy = Anatomy(project_name)
+            anatomy = Anatomy(project_name, project_entity=context["project"])
             repre_context["root"] = anatomy.roots
             path = StringTemplate(template).format(repre_context)
         else:

--- a/client/ayon_houdini/plugins/load/load_filepath.py
+++ b/client/ayon_houdini/plugins/load/load_filepath.py
@@ -25,6 +25,8 @@ def remove_format_spec(template: str, key: str) -> str:
 
     """
     # Find all {key:foobar} and remove the `:foobar`
+    # Pattern will be like `({key):[^}]+(})` where we use the captured groups
+    # to keep those parts in the resulting string
     pattern = f"({{{key}):[^}}]+(}})"
     return re.sub(pattern, r"\1\2", template)
 


### PR DESCRIPTION
## Changelog Description

Load UDIM tokens as `<UDIM>` and frame tokens from template as `$F{padding}`

## Additional info

This now uses the formatted template from the representation to define the `frame` and `udim` tokens in the full path. Hence, this should technically now also be able to support a filepath with both UDIMs and frames (although I don't think we have anything yet that publishes that)

## Testing notes:

1. Load filepath to node should still work
2. Published UDIM sequences should load with `<UDIM>` token.
