### PR TITLE
Enable use selection by default on creators

### DIFF
--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -234,7 +234,7 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
 
     def get_pre_create_attr_defs(self):
         return [
-            BoolDef("use_selection", label="Use selection")
+            BoolDef("use_selection", default=True, label="Use selection")
         ]
 
     @staticmethod


### PR DESCRIPTION
## Changelog Description

Enable "use selection" by default on creators (pre create attribute)

## Additional info

Why?

1. New users expect this behavior.
2. It matches most other host integrations, like blender, maya, cinema4d, aftereffects, substance painter, resolve

Do note that `ayon-nuke` also has it disabled by default.
Also, the legacy creator (long time ago) also had it enabled by default.

## Testing notes:

1. Open Publisher UI on create tab...
2. Creators should default with "Use Selection" checkbox enabled.