### PR TITLE
Create Creator via TAB with null, keep null selected

### DIFF
--- a/client/ayon_houdini/api/creator_node_shelves.py
+++ b/client/ayon_houdini/api/creator_node_shelves.py
@@ -89,6 +89,7 @@ def create_interactive(creator_identifier, **kwargs):
     #   to a method on the Creators for which this could be the default
     #   implementation.
     pane = stateutils.activePane(kwargs)
+    is_null_created = False
     if isinstance(pane, hou.NetworkEditor):
         pwd = pane.pwd()
         project_name = context.get_current_project_name()
@@ -111,7 +112,10 @@ def create_interactive(creator_identifier, **kwargs):
         tool_fn = CATEGORY_GENERIC_TOOL.get(pwd.childTypeCategory())
         if tool_fn is not None:
             out_null = tool_fn(kwargs, "null")
-            out_null.setName("OUT_{}".format(product_name), unique_name=True)
+            if out_null:
+                out_null.setName("OUT_{}".format(product_name),
+                                 unique_name=True)
+                is_null_created = True
 
     before = context.instances_by_id.copy()
 
@@ -123,11 +127,16 @@ def create_interactive(creator_identifier, **kwargs):
     )
 
     # For convenience we set the new node as current since that's much more
-    # familiar to the artist when creating a node interactively
+    # familiar to the artist when creating a node interactively. However
+    # we do not selected if the user used the "null" place down functionality
     # TODO Allow to disable auto-select in studio settings or user preferences
+    #  allow to choose:
+    #  - always select instance node
+    #  - never select instance node
+    #  - select null if created else select instance node (current default)
     after = context.instances_by_id
     new = set(after) - set(before)
-    if new:
+    if new and not is_null_created:
         # Select the new instance
         for instance_id in new:
             instance = after[instance_id]

--- a/client/ayon_houdini/api/creator_node_shelves.py
+++ b/client/ayon_houdini/api/creator_node_shelves.py
@@ -131,7 +131,7 @@ def create_interactive(creator_identifier, **kwargs):
 
     # For convenience we set the new node as current since that's much more
     # familiar to the artist when creating a node interactively. However
-    # we do not selected if the user used the "null" place down functionality
+    # we do not select it if the user used the "null" place down functionality
     # TODO Allow to disable auto-select in studio settings or user preferences
     #  allow to choose:
     #  - always select instance node

--- a/client/ayon_houdini/api/creator_node_shelves.py
+++ b/client/ayon_houdini/api/creator_node_shelves.py
@@ -112,6 +112,9 @@ def create_interactive(creator_identifier, **kwargs):
         tool_fn = CATEGORY_GENERIC_TOOL.get(pwd.childTypeCategory())
         if tool_fn is not None:
             out_null = tool_fn(kwargs, "null")
+            # TODO: For whatever reason the code does not continue if the
+            #  user cancels the operation with escape; yet also no error seems
+            #  to be raised.
             if out_null:
                 out_null.setName("OUT_{}".format(product_name),
                                  unique_name=True)


### PR DESCRIPTION
## Changelog Description

When creating a ROP using a Creator from the TAB menu in the node network it'd select the ROP node after placing down the Null. This was quite confusing because it'd take you out of your working area UNLESS you had your current panel "pinned" explicitly.

With this change, we instead keep the Null selected (since it'll be preconfigured on the ROP anyway) so that you can still continue to work where you were and deal with the ROPs later.

## Additional info

This may be nice to expose in settings to 'toggle' the behavior. But it may actually be more of a user preference than studio preference?

## Testing notes:

1. Go to /stage
2. Press TAB
3. Use `Create USD`

![image](https://github.com/user-attachments/assets/0011ce96-9271-453d-9dbd-8080e1510dfb)

4. Place the null.
5. The null should remain selected.