### PR TITLE
Review: Don't add ftrack family

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_review_data.py
+++ b/client/ayon_houdini/plugins/publish/collect_review_data.py
@@ -22,9 +22,6 @@ class CollectHoudiniReviewData(plugin.HoudiniInstancePlugin):
         instance.data["handleEnd"] = 0
         instance.data["fps"] = instance.context.data["fps"]
 
-        # Enable ftrack functionality
-        instance.data.setdefault("families", []).append('ftrack')
-
         # Get the camera from the rop node to collect the focal length
         ropnode_path = instance.data["instance_node"]
         ropnode = hou.node(ropnode_path)


### PR DESCRIPTION
## Changelog Description
Do not add ftrack family to review instance automatically.

## Additional info
It is job of ftrack addon to care about it.

## Testing notes:
1. Create package, upload to server, add to bundle (with ftrack addon).
2. Review should go to ftrack.
