### PR TITLE
Support Houdini context options from the ROP node for the USD collectors + validations

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_output_node.py
+++ b/client/ayon_houdini/plugins/publish/collect_output_node.py
@@ -6,7 +6,7 @@ from ayon_houdini.api import plugin
 class CollectOutputSOPPath(plugin.HoudiniInstancePlugin):
     """Collect the out node's SOP/COP Path value."""
 
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.45
     families = [
         "pointcache",
         "camera",
@@ -16,7 +16,9 @@ class CollectOutputSOPPath(plugin.HoudiniInstancePlugin):
         "usdrender",
         "redshiftproxy",
         "staticMesh",
-        "model"
+        "model",
+        "usdrender",
+        "usdrop"
     ]
 
     label = "Collect Output Node Path"

--- a/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -46,7 +46,7 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
 
         filenames = []
         files_by_product = {}
-        stage = node.stage()
+        stage = instance.data["stage"]
         for prim_path in self.get_render_products(rop_node, stage):
             prim = stage.GetPrimAtPath(prim_path)
             if not prim or not prim.IsA(pxr.UsdRender.Product):

--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -71,23 +71,13 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
 
     def process(self, instance):
 
-        rop: hou.RopNode = hou.node(instance.data.get("instance_node"))
-        if not rop:
+        # Get Sdf.Layers from "Collect ROP Sdf Layers and USD Stage" plug-in
+        layers = instance.data.get("layers")
+        if layers is None:
+            self.log.warning(f"No USD layers found on instance: {instance}")
             return
 
-        lop_node: hou.LopNode = instance.data.get("output_node")
-        if not lop_node:
-            return
-
-        above_break_layers = set(lop_node.layersAboveLayerBreak())
-
-        stage = lop_node.stage()
-        layers = [
-            layer for layer
-            in stage.GetLayerStack(includeSessionLayers=False)
-            if layer.identifier not in above_break_layers
-        ]
-
+        layers: List[Sdf.Layer]
         instance_resources = self.get_layer_assets(layers)
 
         # Define a relative asset remapping for the USD Extractor so that

--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -6,7 +6,6 @@ from typing import List, Optional
 import dataclasses
 
 import pyblish.api
-import hou
 from pxr import Sdf
 
 from ayon_houdini.api import plugin

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -1,5 +1,6 @@
 import json
 import contextlib
+from typing import Dict
 
 import hou
 from pxr import Sdf, Usd
@@ -13,7 +14,7 @@ from ayon_houdini.api.lib import (
 )
 
 
-def copy_stage_layers(stage) -> dict[Sdf.Layer, Sdf.Layer]:
+def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
     # Create a mapping from original layers to their copies
     layer_mapping = {}
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -23,7 +23,7 @@ def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
         # It seems layer.IsAnonymous() fails (does not exist yet?) so we use
         # the identifier to check if it is an anonymous layer
         if not Sdf.Layer.IsAnonymousLayerIdentifier(layer.identifier):
-            # We disregard non-anonmyous layers for replacing and assume
+            # We disregard non-anonymous layers for replacing and assume
             # they are static enough for our use case.
             continue
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -15,6 +15,16 @@ from ayon_houdini.api.lib import (
 
 
 def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
+    """Copy a stage's anonymous layers to new in-memory layers.
+
+    The layers will be remapped to use the copied layers instead of the
+    original layers if e.g. the root layer uses one of the other layers.
+
+    Returns:
+        Dict[Sdf.Layer, Sdf.Layer]: Mapping from original layers to
+            copied layers.
+
+    """
     # Create a mapping from original layers to their copies
     layer_mapping: Dict[Sdf.Layer, Sdf.Layer] = {}
 
@@ -28,6 +38,14 @@ def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
         copied_layer = Sdf.Layer.CreateAnonymous()
         copied_layer.TransferContent(layer)
         layer_mapping[layer] = copied_layer
+
+    # Remap all used layers in the root layer
+    copied_root_layer = layer_mapping[stage.GetRootLayer()]
+    for old_layer, new_layer in layer_mapping.items():
+        copied_root_layer.UpdateCompositionAssetDependency(
+            old_layer.identifier,
+            new_layer.identifier
+        )
 
     return layer_mapping
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -27,21 +27,9 @@ def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
             # they are static enough for our use case.
             continue
 
-        # Sdf.Layer.TransferContent seems to crash, so instead we export
-        # and import (serialize/deserialize) to make a unique copy.
-        layer_str = layer.ExportToString()
         copied_layer = Sdf.Layer.CreateAnonymous()
-        copied_layer.ImportFromString(layer_str)
+        copied_layer.TransferContent(layer)
         layer_mapping[layer] = copied_layer
-
-    # Remap all used layers in the root layer
-    # TODO: Confirm whether this is technically sufficient?
-    copied_root_layer = layer_mapping[stage.GetRootLayer()]
-    for old_layer, new_layer in layer_mapping.items():
-        copied_root_layer.UpdateCompositionAssetDependency(
-            old_layer.identifier,
-            new_layer.identifier
-        )
 
     return layer_mapping
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -23,7 +23,6 @@ def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
     Returns:
         Dict[Sdf.Layer, Sdf.Layer]: Mapping from original layers to
             copied layers.
-
     """
     # Create a mapping from original layers to their copies
     layer_mapping: Dict[Sdf.Layer, Sdf.Layer] = {}

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -80,10 +80,21 @@ class CollectUsdRenderLayerAndStage(plugin.HoudiniInstancePlugin):
             # Set the context options of the ROP node.
             stack.enter_context(context_options(options))
 
+            # Force cook. There have been some cases where the LOP node
+            # just would not return the USD stage without force cooking it.
+            lop_node.cook(force=True)
+
             # Get stage and layers from the LOP node.
             stage = lop_node.stage(use_last_cook_context_options=False,
                                    apply_viewport_overrides=False,
                                    apply_post_layers=False)
+            if stage is None:
+                self.log.error(
+                    "Unable to get USD stage from LOP node: "
+                    f"{lop_node.path()}. It may have failed to cook due to "
+                    "errors in the node graph.")
+                return
+
             above_break_layers = set(lop_node.layersAboveLayerBreak(
                 use_last_cook_context_options=False))
             layers = [

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -1,0 +1,126 @@
+import json
+import contextlib
+
+import hou
+from pxr import Sdf, Usd
+import pyblish.api
+
+from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import (
+    get_lops_rop_context_options,
+    context_options,
+    update_mode_context
+)
+
+
+def copy_stage_layers(stage) -> dict[Sdf.Layer, Sdf.Layer]:
+    # Create a mapping from original layers to their copies
+    layer_mapping = {}
+
+    # Copy each layer
+    for layer in stage.GetLayerStack(includeSessionLayers=False):
+        # It seems layer.IsAnonymous() fails (does not exist yet?) so we use
+        # the identifier to check if it is an anonymous layer
+        if not Sdf.Layer.IsAnonymousLayerIdentifier(layer.identifier):
+            # We disregard non-anonmyous layers for replacing and assume
+            # they are static enough for our use case.
+            continue
+
+        # Sdf.Layer.TransferContent seems to crash, so instead we export
+        # and import (serialize/deserialize) to make a unique copy.
+        layer_str = layer.ExportToString()
+        copied_layer = Sdf.Layer.CreateAnonymous()
+        copied_layer.ImportFromString(layer_str)
+        layer_mapping[layer] = copied_layer
+
+    # Remap all used layers in the root layer
+    # TODO: Confirm whether this is technically sufficient?
+    copied_root_layer = layer_mapping[stage.GetRootLayer()]
+    for old_layer, new_layer in layer_mapping.items():
+        copied_root_layer.UpdateCompositionAssetDependency(
+            old_layer.identifier,
+            new_layer.identifier
+        )
+
+    return layer_mapping
+
+
+class CollectUsdRenderLayerAndStage(plugin.HoudiniInstancePlugin):
+    """Collect USD stage and layers below layer break for USD ROPs.
+
+    This collects an in-memory copy of the Usd.Stage that can be used in other
+    collectors and validations. It also collects the Sdf.Layer objects up to
+    the layer break (ignoring any above).
+
+    It only creates an in-memory copy of anonymous layers and assumes that any
+    intended to live on disk are already static written to disk files or at
+    least the loaded Sdf.Layer to not be updated during publishing.
+
+    It collects the stage and layers from the LOP node connected to the USD ROP
+    with the context options set on the ROP node. This ensures the graph is
+    evaluated similar to how the ROP node would process it on export.
+
+    """
+
+    label = "Collect ROP Sdf Layers and USD Stage"
+    # Run after Collect Output Node
+    order = pyblish.api.CollectorOrder
+    hosts = ["houdini"]
+    families = ["usdrender", "usdrop"]
+
+    def process(self, instance):
+
+        lop_node = instance.data.get("output_node")
+        if not lop_node:
+            return
+
+        lop_node: hou.LopNode
+        rop: hou.RopNode = hou.node(instance.data["instance_node"])
+        options = get_lops_rop_context_options(rop)
+
+        # Log the context options
+        self.log.debug(
+            "Collecting USD stage with context options:\n"
+            f"{json.dumps(options, indent=4)}")
+
+        with contextlib.ExitStack() as stack:
+            # Force cooking the lop node does not seem to work, so we
+            # must set the cook mode to "Update" for this to work
+            stack.enter_context(update_mode_context(hou.updateMode.AutoUpdate))
+
+            # Set the context options of the ROP node.
+            stack.enter_context(context_options(options))
+
+            # Get stage and layers from the LOP node.
+            stage = lop_node.stage(use_last_cook_context_options=False,
+                                   apply_viewport_overrides=False,
+                                   apply_post_layers=False)
+            above_break_layers = set(lop_node.layersAboveLayerBreak(
+                use_last_cook_context_options=False))
+            layers = [
+                layer for layer
+                in stage.GetLayerStack(includeSessionLayers=False)
+                if layer.identifier not in above_break_layers
+            ]
+
+            # The returned stage and layer in memory is shared across cooks
+            # so it is the exact same stage and layer object each time if
+            # multiple ROPs point to the same LOP node (or its layer's graph).
+            # As such, we must explicitly copy the stage and layers to ensure
+            # the next 'cook' does not affect the stage and layers of the
+            # previous instance or by any other process down the line.
+            # Get a copy of the stage and layers so that any in houdini edit
+            # or another recook from another instance of the same LOP layers
+            # does not influence this collected stage and layers.
+            copied_layer_mapping = copy_stage_layers(stage)
+            copied_stage = Usd.Stage.Open(
+                copied_layer_mapping[stage.GetRootLayer()])
+            copied_layers = [
+                # Remap layers only that were remapped (anonymous layers
+                # only). If the layer was not remapped, then use the
+                # original
+                copied_layer_mapping.get(layer, layer) for layer in layers
+            ]
+
+            instance.data["layers"] = copied_layers
+            instance.data["stage"] = copied_stage

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -20,9 +20,7 @@ def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
 
     # Copy each layer
     for layer in stage.GetLayerStack(includeSessionLayers=False):
-        # It seems layer.IsAnonymous() fails (does not exist yet?) so we use
-        # the identifier to check if it is an anonymous layer
-        if not Sdf.Layer.IsAnonymousLayerIdentifier(layer.identifier):
+        if not layer.anonymous:
             # We disregard non-anonymous layers for replacing and assume
             # they are static enough for our use case.
             continue

--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -16,7 +16,7 @@ from ayon_houdini.api.lib import (
 
 def copy_stage_layers(stage) -> Dict[Sdf.Layer, Sdf.Layer]:
     # Create a mapping from original layers to their copies
-    layer_mapping = {}
+    layer_mapping: Dict[Sdf.Layer, Sdf.Layer] = {}
 
     # Copy each layer
     for layer in stage.GetLayerStack(includeSessionLayers=False):

--- a/client/ayon_houdini/plugins/publish/validate_usd_look_assignments.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_look_assignments.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import inspect
-import hou
 from pxr import Usd, UsdShade, UsdGeom
 
 import pyblish.api
@@ -54,16 +53,18 @@ class ValidateUsdLookAssignments(plugin.HoudiniInstancePlugin,
         if not self.is_active(instance.data):
             return
 
-        lop_node: hou.LopNode = instance.data.get("output_node")
-        if not lop_node:
+        # Get Usd.Stage from "Collect ROP Sdf Layers and USD Stage" plug-in
+        stage = instance.data.get("stage")
+        if not stage:
+            self.log.debug("No USD stage found.")
             return
+        stage: Usd.Stage
 
         # We iterate the composed stage for code simplicity; however this
         # means that it does not validate across e.g. multiple model variants
         # but only checks against the current composed stage. Likely this is
         # also what you actually want to validate, because your look might not
         # apply to *all* model variants.
-        stage = lop_node.stage()
         invalid = []
         for prim in stage.Traverse():
             if not prim.IsA(UsdGeom.Gprim):

--- a/client/ayon_houdini/plugins/publish/validate_usd_look_contents.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_look_contents.py
@@ -3,7 +3,6 @@ import inspect
 from typing import List, Union
 from functools import partial
 
-import hou
 from pxr import Sdf
 import pyblish.api
 
@@ -44,20 +43,11 @@ class ValidateUsdLookContents(plugin.HoudiniInstancePlugin):
 
     def process(self, instance):
 
-        lop_node: hou.LopNode = instance.data.get("output_node")
-        if not lop_node:
-            return
-
-        # Get layers below layer break
-        above_break_layers = set(layer for layer in lop_node.layersAboveLayerBreak())
-        stage = lop_node.stage()
-        layers = [
-            layer for layer
-            in stage.GetLayerStack(includeSessionLayers=False)
-            if layer.identifier not in above_break_layers
-        ]
+        # Get Sdf.Layers from "Collect ROP Sdf Layers and USD Stage" plug-in
+        layers = instance.data.get("layers")
         if not layers:
             return
+        layers: List[Sdf.Layer]
 
         # The Sdf.PrimSpec type name will not have knowledge about inherited
         # types for the type, name. So we pre-collect all invalid types

--- a/client/ayon_houdini/plugins/publish/validate_usd_look_material_defs.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_look_material_defs.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 import inspect
-import hou
-from pxr import Sdf, UsdShade
+from typing import List
+
+from pxr import Sdf, Usd, UsdShade
 import pyblish.api
 
 from ayon_core.pipeline.publish import (
@@ -34,21 +35,12 @@ class ValidateLookShaderDefs(plugin.HoudiniInstancePlugin,
         if not self.is_active(instance.data):
             return
 
-        lop_node: hou.LopNode = instance.data.get("output_node")
-        if not lop_node:
-            return
-
-        # Get layers below layer break
-        above_break_layers = set(
-            layer for layer in lop_node.layersAboveLayerBreak())
-        stage = lop_node.stage()
-        layers = [
-            layer for layer
-            in stage.GetLayerStack(includeSessionLayers=False)
-            if layer.identifier not in above_break_layers
-        ]
+        # Get Sdf.Layers from "Collect ROP Sdf Layers and USD Stage" plug-in
+        layers = instance.data.get("layers")
         if not layers:
             return
+        stage: Usd.Stage = instance.data["stage"]
+        layers: List[Sdf.Layer]
 
         # The Sdf.PrimSpec type name will not have knowledge about inherited
         # types for the type, name. So we pre-collect all invalid types

--- a/client/ayon_houdini/plugins/publish/validate_usd_render_arnold.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_render_arnold.py
@@ -163,7 +163,7 @@ class ValidateUSDRenderArnoldSettings(plugin.HoudiniInstancePlugin):
 
         # Validate Arnold Product Type is enabled on the Arnold Render Settings
         # This is confirmed by the `includeAovs` attribute on the RenderProduct
-        stage: pxr.Usd.Stage = node.stage()
+        stage: pxr.Usd.Stage = instance.data["stage"]
         invalid = False
         for prim_path in instance.data.get("usdRenderProducts", []):
             prim = stage.GetPrimAtPath(prim_path)
@@ -223,8 +223,7 @@ class ValidateUSDRenderCamera(plugin.HoudiniInstancePlugin):
             # be validated by another plug-in.
             return
 
-        stage = lop_node.stage()
-
+        stage = instance.data["stage"]
         render_settings = get_usd_render_rop_rendersettings(rop_node, stage,
                                                             logger=self.log)
         if not render_settings:

--- a/client/ayon_houdini/plugins/publish/validate_usd_rop_default_prim.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_rop_default_prim.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import inspect
+from typing import List
+
 import hou
 from pxr import Sdf
 import pyblish.api
@@ -30,20 +32,12 @@ class ValidateUSDRopDefaultPrim(plugin.HoudiniInstancePlugin):
             )
             return
 
-        lop_node: hou.LopNode = instance.data.get("output_node")
-        if not lop_node:
-            return
-
-        above_break_layers = set(layer for layer in lop_node.layersAboveLayerBreak())
-        stage = lop_node.stage()
-        layers = [
-            layer for layer
-            in stage.GetLayerStack(includeSessionLayers=False)
-            if layer.identifier not in above_break_layers
-        ]
+        # Get Sdf.Layers from "Collect ROP Sdf Layers and USD Stage" plug-in
+        layers = instance.data.get("layers")
         if not layers:
             self.log.error("No USD layers found. This is likely a bug.")
             return
+        layers: List[Sdf.Layer]
 
         # TODO: This only would detect any local opinions on that prim and thus
         #   would fail to detect if a sublayer added on the stage root layer

--- a/client/ayon_houdini/plugins/publish/validate_vdb_output_node.py
+++ b/client/ayon_houdini/plugins/publish/validate_vdb_output_node.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-import contextlib
 import hou
 
 import pyblish.api
 from ayon_core.pipeline import PublishXmlValidationError
 
 from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import update_mode_context
 from ayon_houdini.api.action import SelectInvalidAction
 
 
@@ -40,16 +40,6 @@ def group_consecutive_numbers(nums):
             end = num
     if start is not None:
         yield _result(start, end)
-
-
-@contextlib.contextmanager
-def update_mode_context(mode):
-    original = hou.updateModeSetting()
-    try:
-        hou.setUpdateMode(mode)
-        yield
-    finally:
-        hou.setUpdateMode(original)
 
 
 def get_geometry_at_frame(sop_node, frame, force=True):


### PR DESCRIPTION
## Changelog Description

Support Houdini context options from the ROP node for the USD collectors + validations

## Additional info

- Collect USD stage and layers with the right context options
- Collect the USD Stage and Sdf Layers once and re-use down the line

With this change you can create a Solaris stage in LOPs that is dependent on context options, e.g. for multi-shot lighting workflows and publishing each of them will now correctly retrieve the expected render products for e.g. USD rendering for that Solaris context and/or whatever is different in the LOPs graph for that particular context.

This also changes the behavior that each validator recollects the stage and layers each time from the LOP. Instead, we query them once, keep in memory and re-use them in validators down the line. Whether this will be entirely correct, safe to do and remain without crashes we'll have to investigate in some good testing of publishing some decently complex graphs of models, looks and render scenes. A bigger test render scene with multi-shot workflow that I had seemed to run fine.

How to best keep the unique cloned layers in memory I wasn't sure about and took me a while to figure out something that didn't crash Houdini or was immensely slow. This now seems to behave consistent - but I have an open USD Alliance forum post [here](https://forum.aousd.org/t/copy-in-memory-stage-and-its-layers-to-be-unique-copies/1946/2) hoping to get even better approaches.

## Testing notes:

1. Set up a scene with context options
2. On the USD ROP set the "Context Options" you want for a particular publish instance.
3. Publish both at the same time.
4. It should've correctly applied the validations and the publish.

Note: The generated USD product being correct isn't much up to us - that's still a regular Houdini ROP render so we would mostly be validating whether our collectors and validators are correctly picking up the context options. Like e.g. having different render product output paths per context, or different textures loaded per context (and have those correctly be published along with a look).