### PR TITLE
Group USD Explict Save Layer Products to "USD Layer" product group

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -137,8 +137,6 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
             layer_inst.data["instance_node"] = instance.data["instance_node"]
             layer_inst.data["render"] = False
             layer_inst.data["output_node"] = creator_node
-            if instance.data.get("productGroup"):
-                layer_inst.data["productGroup"] = instance.data["productGroup"]
 
             # Inherit "use handles" from the source instance
             # TODO: Do we want to maybe copy full `publish_attributes` instead?
@@ -148,8 +146,9 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
             )
 
             # Allow this subset to be grouped into a USD Layer on creation
-            layer_inst.data["subsetGroup"] = "USD Layer"
-
+            layer_inst.data["productGroup"] = (
+                instance.data.get("productGroup") or "USD Layer"
+            )
             # For now just assume the representation will get published
             representation = {
                 "name": "usd",


### PR DESCRIPTION
## Changelog Description

USD Explicit Save Layer products should go into the `USD Layer` product group similar to how USD contribution workflow does that.

## Additional info

Fixes https://github.com/ynput/ayon-houdini/issues/129

For context on "Explicit Layer Save Paths" see:

- https://github.com/ynput/ayon-houdini/pull/80
- https://github.com/ynput/ayon-houdini/pull/59

## Testing notes:

1. Create a USD publish with Explicit Save Layers that will turn into dependent products of their own.
2. Those newly created products should now by default go into a "USD Layer" product group.
3. This should work both with USD contribution workflow enabled AND disabled.