### PR TITLE
Look: Validate material allow bindings from any purpose and configure in settings

### DIFF
--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -167,6 +167,9 @@ class PublishPluginsModel(BaseSettingsModel):
     ValidateWorkfilePaths: ValidateWorkfilePathsModel = SettingsField(
         default_factory=ValidateWorkfilePathsModel,
         title="Validate workfile paths settings")
+    ValidateUsdLookAssignments: BasicEnabledStatesModel = SettingsField(
+        default_factory=BasicEnabledStatesModel,
+        title="Validate USD Look Assignments")
     ValidateUSDRenderProductPaths: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Validate USD Render Product Paths")
@@ -255,6 +258,11 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
             "$HIP",
             "$JOB"
         ]
+    },
+    "ValidateUsdLookAssignments": {
+        "enabled": True,
+        "optional": True,
+        "active": True
     },
     "ValidateUSDRenderProductPaths": {
         "enabled": False,


### PR DESCRIPTION
## Changelog Description

Validate material allow bindings from any purpose, not just the `UsdShade.Tokens.allPurpose`.

This also exposes the plug-in to settings to allow the default state or disable completely, etc.

## Additional review information

n/a

## Testing notes:

1. Assign a material with a binding that is not "All" but also allow preview or full render purposes.

![image](https://github.com/user-attachments/assets/174ec106-63cc-47eb-a2da-bf2f883471f1)

