### PR TITLE
Do not enforce "Match Maya Mask" aperture expression on Load Camera (abc)

### DIFF
--- a/client/ayon_houdini/plugins/load/load_camera.py
+++ b/client/ayon_houdini/plugins/load/load_camera.py
@@ -1,4 +1,7 @@
+from typing import Optional
 import hou
+
+from ayon_core.lib import EnumDef
 from ayon_core.pipeline import get_representation_path
 
 from ayon_houdini.api import (
@@ -13,6 +16,14 @@ from ayon_houdini.api.lib import (
 
 ARCHIVE_EXPRESSION = ('__import__("_alembic_hom_extensions")'
                       '.alembicGetCameraDict')
+
+
+def get_expression(parm: hou.Parm) -> Optional[str]:
+    try:
+        return parm.expression()
+    except hou.OperationFailed:
+        # No expression present
+        pass
 
 
 def transfer_non_default_values(src, dest, ignore=None):
@@ -62,13 +73,7 @@ def transfer_non_default_values(src, dest, ignore=None):
             # are implementation details
             continue
 
-        expression = None
-        try:
-            expression = parm.expression()
-        except hou.OperationFailed:
-            # No expression present
-            pass
-
+        expression = get_expression(parm)
         if expression is not None and ARCHIVE_EXPRESSION in expression:
             # Assume it's part of the automated connections that the
             # Alembic Archive makes on loading of the camera and thus we do
@@ -94,7 +99,40 @@ class CameraLoader(plugin.HoudiniLoader):
     icon = "code-fork"
     color = "orange"
 
-    def load(self, context, name=None, namespace=None, data=None):
+    camera_aperture_expression = "default"
+
+    _match_maya_render_mask_expression = """
+# Match maya render mask (logic from Houdini's own FBX importer)
+node = hou.pwd()
+resx = node.evalParm('resx')
+resy = node.evalParm('resy')
+aspect = node.evalParm('aspect')
+aperture *= min(1, (resx / resy * aspect) / 1.5)
+return aperture
+"""
+
+    @classmethod
+    def get_options(cls, contexts):
+        return [
+            EnumDef(
+                "cameraApertureExpression",
+                label="Camera Aperture Expression",
+                items=[
+                    {"label": "Houdini Default", "value": "default"},
+                    {"label": "Match Maya render mask", "value": "match_maya"}
+                ],
+                default=cls.camera_aperture_expression,
+                tooltip=(
+                    "Set the aperture expression on the camera from the "
+                    "Alembic using either:\n"
+                    "- Houdini default expression\n"
+                    "- Match the Maya render mask (which matches Houdini's "
+                    "FBX Import camera expression."
+                )
+            )
+        ]
+
+    def load(self, context, name=None, namespace=None, options=None):
 
         # Format file name, Houdini only wants forward slashes
         file_path = self.filepath_from_context(context).replace("\\", "/")
@@ -120,7 +158,11 @@ class CameraLoader(plugin.HoudiniLoader):
         nodes = [node]
 
         camera = get_camera_from_container(node)
-        self._match_maya_render_mask(camera)
+
+        if options.get("cameraApertureExpression",
+                       self.camera_aperture_expression) == "match_maya":
+            self._match_maya_render_mask(camera)
+
         set_camera_resolution(camera, entity=context["folder"])
         self[:] = nodes
 
@@ -161,7 +203,14 @@ class CameraLoader(plugin.HoudiniLoader):
                                     # "icon_scale" just skip that completely
                                     ignore={"scale"})
 
-        self._match_maya_render_mask(new_camera)
+        # Detect whether the camera was loaded with the "Match Maya render
+        # mask" before. If so, we want to maintain that expression on update.
+        if (
+                self._match_maya_render_mask_expression
+                in get_expression(temp_camera.parm("aperture"))
+        ):
+            self._match_maya_render_mask(new_camera)
+
         set_camera_resolution(new_camera)
 
         temp_camera.destroy()
@@ -196,17 +245,10 @@ class CameraLoader(plugin.HoudiniLoader):
 
     def _match_maya_render_mask(self, camera):
         """Workaround to match Maya render mask in Houdini"""
-
         parm = camera.parm("aperture")
+        print(f"Applying match Maya render mask expression to: {parm.path()}")
+
         expression = parm.expression()
         expression = expression.replace("return ", "aperture = ")
-        expression += """
-# Match maya render mask (logic from Houdini's own FBX importer)
-node = hou.pwd()
-resx = node.evalParm('resx')
-resy = node.evalParm('resy')
-aspect = node.evalParm('aspect')
-aperture *= min(1, (resx / resy * aspect) / 1.5)
-return aperture
-"""
+        expression += self._match_maya_render_mask_expression
         parm.setExpression(expression, language=hou.exprLanguage.Python)

--- a/server/settings/load.py
+++ b/server/settings/load.py
@@ -1,6 +1,28 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+
+def camera_aperture_expression_enum_options():
+    return [
+        {"label": "Houdini Default", "value": "default"},
+        {"label": "Match Maya render mask", "value": "match_maya"}
+    ]
+
+
+class CameraLoaderModel(BaseSettingsModel):
+    camera_aperture_expression: str = SettingsField(
+        "default",
+        title="Camera Aperture Expression on load",
+        enum_resolver=camera_aperture_expression_enum_options,
+        description=(
+            "Allows to override the Houdini default expression on loaded "
+            "Alembic cameras by one that should better match the Maya Render "
+            "Mask. The alternative Match Maya Render mask expression is based "
+            "on Houdini's own expression it applies on FBX import of cameras."
+        )
+    )
+
+
 # Load Plugins
 class LoadUseAYONEntityURIModel(BaseSettingsModel):
     use_ayon_entity_uri: bool = SettingsField(
@@ -15,6 +37,9 @@ class LoadUseAYONEntityURIModel(BaseSettingsModel):
 
 
 class LoadPluginsModel(BaseSettingsModel):
+    CameraLoader: CameraLoaderModel = SettingsField(
+        default_factory=CameraLoaderModel,
+        title="Load Camera (abc)")
     LOPLoadAssetLoader: LoadUseAYONEntityURIModel = SettingsField(
         default_factory=LoadUseAYONEntityURIModel,
         title="LOP Load Asset")


### PR DESCRIPTION
## Changelog Description

Do not enforce "Match Maya Mask" aperture expression on Load Camera (abc).

Instead, allow an option for the user to choose with a setting in settings to pick a default at `ayon+settings://houdini/load/CameraLoader/camera_aperture_expression`

This does now default to the Houdini default behavior instead of the "Match Maya Render Mask" because it seems more aligned with what users seem to want. To keep the old default behavior on load that setting would have to be set to `match_maya`.

## Additional review information

![image](https://github.com/user-attachments/assets/930432ef-77cf-4083-b1b8-2c3862db17a6)

Fixes #106

## Testing notes:

1. Load camera should default to regular Houdini expression on Alembic camera load
2. Unless the option was chosen to use the Match Maya Render Mask expression.
3. On update the chosen option should persist - so that if on load maya render mask was chosen, it would be preserved on updating.
4. It should be backwards compatible on updates for already loaded cameras in the scene (preserving the match maya render mask expression).