### PR TITLE
Changing the order of BGEO cache format while creating

### DIFF
--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -70,16 +70,16 @@ class CreateBGEO(plugin.HoudiniCreator):
         attrs = super().get_pre_create_attr_defs()
         bgeo_enum = [
             {
-                "value": "bgeo",
-                "label": "uncompressed bgeo (.bgeo)"
+                "value": "bgeo.sc",
+                "label": "BLOSC compressed bgeo (.bgeo.sc)"
             },
             {
                 "value": "bgeosc",
                 "label": "BLOSC compressed bgeo (.bgeosc)"
             },
             {
-                "value": "bgeo.sc",
-                "label": "BLOSC compressed bgeo (.bgeo.sc)"
+                "value": "bgeo",
+                "label": "uncompressed bgeo (.bgeo)"
             },
             {
                 "value": "bgeo.gz",

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -96,7 +96,12 @@ class CreateBGEO(plugin.HoudiniCreator):
         ]
 
         return attrs + [
-            EnumDef("bgeo_type", bgeo_enum, label="BGEO Options"),
+            EnumDef(
+                "bgeo_type",
+                bgeo_enum,
+                default="bgeo.sc",
+                label="BGEO Options"
+            ),
         ] + self.get_instance_attr_defs()
 
     def get_network_categories(self):

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -70,16 +70,16 @@ class CreateBGEO(plugin.HoudiniCreator):
         attrs = super().get_pre_create_attr_defs()
         bgeo_enum = [
             {
-                "value": "bgeo.sc",
-                "label": "BLOSC compressed bgeo (.bgeo.sc)"
+                "value": "bgeo",
+                "label": "uncompressed bgeo (.bgeo)"
             },
             {
                 "value": "bgeosc",
                 "label": "BLOSC compressed bgeo (.bgeosc)"
             },
             {
-                "value": "bgeo",
-                "label": "uncompressed bgeo (.bgeo)"
+                "value": "bgeo.sc",
+                "label": "BLOSC compressed bgeo (.bgeo.sc)"
             },
             {
                 "value": "bgeo.gz",


### PR DESCRIPTION
## Changelog Description
Changing the order of BGEO cache while creating the point cache to bgeo.sc instead bgeo
since bgeo.sc in a compressed format and widely used


## Testing notes:
1. when creating the point cache, by default it should be bgeo.sc
2. everything should work as expected
