### PR TITLE
Publish-BGEO-cache-using-the-existing-frames

### DIFF
--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -13,13 +13,18 @@ class CreateBGEO(plugin.HoudiniCreator):
     product_type = "pointcache"
     icon = "gears"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
 
         instance_data.update({"node_type": "geometry"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
-        creator_attributes["local_no_render"] = pre_create_data["local_no_render"]
+        
+        for key in ["render_target"]:
+            if key in pre_create_data:
+                creator_attributes[key] = pre_create_data[key]
 
         instance = super(CreateBGEO, self).create(
             product_name,
@@ -61,13 +66,17 @@ class CreateBGEO(plugin.HoudiniCreator):
         instance_node.setParms(parms)
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+            "farm_no_render": "Use existing frames (farm)"
+        }
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False),
-            BoolDef("local_no_render",
-                    label="Use existing frames (local)",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -19,6 +19,7 @@ class CreateBGEO(plugin.HoudiniCreator):
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
         creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["local_no_render"] = pre_create_data["local_no_render"]
 
         instance = super(CreateBGEO, self).create(
             product_name,
@@ -63,6 +64,9 @@ class CreateBGEO(plugin.HoudiniCreator):
         return [
             BoolDef("farm",
                     label="Submitting to Farm",
+                    default=False),
+            BoolDef("local_no_render",
+                    label="Use existing frames (local)",
                     default=False)
         ]
 

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -18,9 +18,9 @@ class CollectDataforCache(plugin.HoudiniInstancePlugin):
 
     def process(self, instance):
         creator_attribute = instance.data["creator_attributes"]
-        farm_enabled = creator_attribute["render_target"]
+        render_target: str = creator_attribute.get("render_target")
         # Determine settings based on render_target value
-        farm_enabled = False if farm_enabled in ["local", "local_no_render"] else farm_enabled
+        farm_enabled = render_target in {"farm", "farm_no_render"}
         instance.data["farm"] = farm_enabled
         if not farm_enabled:
             self.log.debug("Caching on farm is disabled. "

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -18,7 +18,9 @@ class CollectDataforCache(plugin.HoudiniInstancePlugin):
 
     def process(self, instance):
         creator_attribute = instance.data["creator_attributes"]
-        farm_enabled = creator_attribute["farm"]
+        farm_enabled = creator_attribute["render_target"]
+        # Determine settings based on render_target value
+        farm_enabled = False if farm_enabled in ["local", "local_no_render"] else farm_enabled
         instance.data["farm"] = farm_enabled
         if not farm_enabled:
             self.log.debug("Caching on farm is disabled. "

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -32,7 +32,7 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         ext = ext.lstrip(".")
 
         creator_attributes = (instance.data["creator_attributes"])
-        if creator_attributes["render_target"] == "local":
+        if creator_attributes.get("render_target") in {"local"}:
             self.render_rop(instance)
         else:
             print("Skipping Houdini local render...")

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -31,10 +31,11 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
-        if instance.data.get("creator_attributes",{}).get("local_no_render"):
-            print("Using Existing Frames")
-        else:
+        creator_attributes = (instance.data["creator_attributes"])
+        if creator_attributes["render_target"] == "local":
             self.render_rop(instance)
+        else:
+            print("Skipping Houdini local render...")
 
         self.validate_expected_frames(instance)
 

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -31,11 +31,13 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
-        creator_attributes = (instance.data["creator_attributes"])
-        if creator_attributes.get("render_target") in {"local"}:
-            self.render_rop(instance)
+        creator_attributes = instance.data["creator_attributes"]
+        if creator_attributes.get("render_target") == "local_no_render":
+            self.log.debug(
+                "Skipping ROP render to use existing frames"
+                f" for instance: {instance}")
         else:
-            print("Skipping Houdini local render...")
+            self.render_rop(instance)
 
         self.validate_expected_frames(instance)
 

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -1,6 +1,5 @@
 import os
 import hou
-import inspect
 
 import pyblish.api
 

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -1,5 +1,6 @@
 import os
 import hou
+import inspect
 
 import pyblish.api
 
@@ -31,7 +32,11 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
-        self.render_rop(instance)
+        if instance.data.get("creator_attributes",{}).get("local_no_render"):
+            print("Using Existing Frames")
+        else:
+            self.render_rop(instance)
+
         self.validate_expected_frames(instance)
 
         # In some cases representation name is not the the extension


### PR DESCRIPTION
## Changelog Description
Publish using the existing frames in houdini BGEO


## Testing notes:
1. When creating added boolean parameter for using the existing frames
2. when publishing if the node is turned on-> it should skip the render and use the existing frames
3. If the node is turned off-> It should render without any issues