### PR TITLE
Fix textures not being collected and published along for `look` products

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_rop_layer_and_stage.py
@@ -68,7 +68,9 @@ class CollectUsdRenderLayerAndStage(plugin.HoudiniInstancePlugin):
 
     label = "Collect ROP Sdf Layers and USD Stage"
     # Run after Collect Output Node
-    order = pyblish.api.CollectorOrder
+    # Run just before regular CollectorOrder to have stage accessible
+    # to default collector orders
+    order = pyblish.api.CollectorOrder - 0.01
     hosts = ["houdini"]
     families = ["usdrender", "usdrop"]
 


### PR DESCRIPTION
## Changelog Description

Fix textures not being collected and published along for `look` products.

## Additional review information

This PR https://github.com/ynput/ayon-houdini/pull/145 made it so that the USD stage and layers is collected once globally for an instance and then accessed downstream by other plug-ins. However, the Collect Look Assets plug-in, using this data runs at the same collector order and hence depending on "chance" that plug-in may load before or after the this one making it unreliable.

## Testing notes:

1. Publish "look" for an asset with textures
2. The textures should be published along and remapped accordingly.
