### PR TITLE
Fix Load Asset LOP and Load Shot LOP

### DIFF
--- a/client/ayon_houdini/plugins/load/load_asset_lop.py
+++ b/client/ayon_houdini/plugins/load/load_asset_lop.py
@@ -1,5 +1,6 @@
 from ayon_core.pipeline import load
 from ayon_houdini.api.lib import find_active_network
+from ayon_houdini.api import hda_utils
 
 import hou
 
@@ -28,21 +29,14 @@ class LOPLoadAssetLoader(load.LoaderPlugin):
         node = network.createNode("ayon::lop_import", node_name=node_name)
         node.moveToGoodPosition()
 
-        # Set representation id
-        parm = node.parm("representation")
-        parm.set(context["representation"]["id"])
-        parm.pressButton()  # trigger callbacks
+        hda_utils.set_node_representation_from_context(node, context)
 
         nodes = [node]
         self[:] = nodes
 
     def update(self, container, context):
         node = container["node"]
-
-        # Set representation id
-        parm = node.parm("representation")
-        parm.set(context["representation"]["id"])
-        parm.pressButton()  # trigger callbacks
+        hda_utils.set_node_representation_from_context(node, context)
 
     def remove(self, container):
         node = container["node"]

--- a/client/ayon_houdini/plugins/load/load_shot_lop.py
+++ b/client/ayon_houdini/plugins/load/load_shot_lop.py
@@ -1,5 +1,6 @@
 from ayon_core.pipeline import load
 from ayon_houdini.api.lib import find_active_network
+from ayon_houdini.api import hda_utils
 
 import hou
 
@@ -28,21 +29,14 @@ class LOPLoadShotLoader(load.LoaderPlugin):
         node = network.createNode("ayon::load_shot", node_name=node_name)
         node.moveToGoodPosition()
 
-        # Set representation id
-        parm = node.parm("representation")
-        parm.set(context["representation"]["id"])
-        parm.pressButton()  # trigger callbacks
+        hda_utils.set_node_representation_from_context(node, context)
 
         nodes = [node]
         self[:] = nodes
 
     def update(self, container, context):
         node = container["node"]
-
-        # Set representation id
-        parm = node.parm("representation")
-        parm.set(context["representation"]["id"])
-        parm.pressButton()  # trigger callbacks
+        hda_utils.set_node_representation_from_context(node, context)
 
     def remove(self, container):
         node = container["node"]


### PR DESCRIPTION
## Changelog Description

Fix Load Asset LOP and Load Shot LOP loading and updating via loader and scene inventory.

## Additional review information

PR #112 changed the parameter callbacks to expressions that worked the other way around. Hence just setting `representation` id on the node and triggering a callback (which does not exist anymore) didn't actually work breaking the loaders for these LOPs.

## Testing notes:

1. Load a Load Asset LOP and Load Shot LOP through loader UI
2. The nodes should be loaded correctly.
3. Update the nodes via the Scene Inventory - update should work.
