### PR TITLE
Remove the :SDF_FORMAT_ARGS: from the collected filenames for Explicit Layer Save paths

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -8,6 +8,7 @@ from ayon_core.pipeline.create import get_product_name
 from ayon_houdini.api import plugin
 import ayon_houdini.api.usd as usdlib
 
+from pxr import Sdf
 import hou
 
 
@@ -103,6 +104,12 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
 
             staging_dir, fname = os.path.split(save_path)
             fname_no_ext, ext = os.path.splitext(fname)
+
+            # The save path may include :SDF_FORMAT_ARGS: which will conflict
+            # with how we end up integrating these files because those will
+            # NOT be included in the actual output filename on disk, so we
+            # remove the SDF_FORMAT_ARGS from the filename.
+            fname = Sdf.Layer.SplitIdentifier(fname)[0]
 
             variant = fname_no_ext
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -102,14 +102,13 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
             # include same USD ROP
             layer_inst.append(rop_node)
 
-            staging_dir, fname = os.path.split(save_path)
+            staging_dir, fname_with_args = os.path.split(save_path)
 
             # The save path may include :SDF_FORMAT_ARGS: which will conflict
             # with how we end up integrating these files because those will
             # NOT be included in the actual output filename on disk, so we
             # remove the SDF_FORMAT_ARGS from the filename.
-            fname = Sdf.Layer.SplitIdentifier(fname)[0]
-
+            fname = Sdf.Layer.SplitIdentifier(fname_with_args)[0]
             fname_no_ext, ext = os.path.splitext(fname)
 
             variant = fname_no_ext
@@ -162,9 +161,12 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
                 "name": "usd",
                 "ext": ext.lstrip("."),
                 "stagingDir": staging_dir,
-                "files": fname
-            }
+                "files": fname,
 
-            self.log.info(representation)
+                # Store an additional key with filenames including the
+                # SDF_FORMAT_ARGS so we can use this to remap paths
+                # accurately later.
+                "files_raw": fname_with_args
+            }
             layer_inst.data.setdefault("representations", []).append(
                 representation)

--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -103,13 +103,14 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
             layer_inst.append(rop_node)
 
             staging_dir, fname = os.path.split(save_path)
-            fname_no_ext, ext = os.path.splitext(fname)
 
             # The save path may include :SDF_FORMAT_ARGS: which will conflict
             # with how we end up integrating these files because those will
             # NOT be included in the actual output filename on disk, so we
             # remove the SDF_FORMAT_ARGS from the filename.
             fname = Sdf.Layer.SplitIdentifier(fname)[0]
+
+            fname_no_ext, ext = os.path.splitext(fname)
 
             variant = fname_no_ext
 
@@ -163,5 +164,7 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
                 "stagingDir": staging_dir,
                 "files": fname
             }
+
+            self.log.info(representation)
             layer_inst.data.setdefault("representations", []).append(
                 representation)

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -120,7 +120,15 @@ def get_source_paths(
     """Return the full source filepaths for an instance's representations"""
 
     staging = repre.get("stagingDir", instance.data.get("stagingDir"))
-    files = repre.get("files", [])
+
+    # Support special `files_raw` key for representations that may originate
+    # from a path in the USD file including `:SDF_FORMAT_ARGS:` which we will
+    # also want to match against.
+    if "files_raw" in repre:
+        files = repre["files_raw"]
+    else:
+        files = repre.get("files", [])
+
     if isinstance(files, list):
         return [os.path.join(staging, fname) for fname in files]
     elif isinstance(files, str):


### PR DESCRIPTION
## Changelog Description

Remove the :SDF_FORMAT_ARGS: from the collected filenames for Explicit Layer Save paths

## Additional review information

This may fix the issue mentioned here: https://community.ynput.io/t/houdini-usd-publish-errors/1944?u=bigroy

## Testing notes:

1. Create asset with component builder
2. Publish as USD