### PR TITLE
Fix Load Asset LOP and Load Shot LOP (but better?) 

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -136,23 +136,52 @@ def set_node_representation_from_context(
     node.setParms(parms)
 
     if ensure_expression_defaults:
-        # The filepath and representation id parms are updated through
-        # expressions, however in older versions they were explicitly set
-        # so we ensure that the current value is set to the default value
-        # with the expression - otherwise the value will be set to the
-        # previously explicitly set overridden value.
-        for parm_name in ["representation", "file"]:
-            parm = node.parm(parm_name)
-            if parm is None:
-                continue
+        ensure_loader_expression_parm_defaults(node)
 
-            if parm.isAtDefault(compare_expressions=True):
-                continue
 
-            locked = parm.isLocked()
-            parm.lock(False)
-            parm.revertToDefaults()
-            parm.lock(locked)
+def ensure_loader_expression_parm_defaults(node):
+    """Reset `representation` and `file` parm to defaults.
+
+    The filepath and representation id parms are updated through expressions,
+    however in older versions they were explicitly set so we ensure that the
+    current value is set to the default value with the expression - otherwise
+    the value will be set to the previously explicitly set overridden value.
+
+    Silently ignores if the parm does not exist or is already at default.
+
+    Args:
+        node (hou.OpNode): The node to reset.
+
+    """
+    for parm_name in ["representation", "file"]:
+        parm = node.parm(parm_name)
+        if parm is None:
+            continue
+
+        # TODO: For whatever reason this still returns True even if the
+        #  expression does not match the default, so for now we always revert
+        # if parm.isAtDefault(compare_expressions=True):
+        #     continue
+
+        default_expression = parm.parmTemplate().defaultExpression()
+        if not default_expression:
+            continue
+
+        default_expression = default_expression[0]
+
+        try:
+            current_expression = parm.expression()
+            if current_expression == default_expression:
+                continue
+        except hou.OperationFailed:
+            pass
+
+        print(f"Enforcing {parm.path()} to default value")
+        locked = parm.isLocked()
+        parm.lock(False)
+        parm.deleteAllKeyframes()
+        parm.revertToDefaults()
+        parm.lock(locked)
 
 
 def get_representation_path(

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/OnLoaded
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/OnLoaded
@@ -12,3 +12,5 @@ def on_duplicate():
 
 if not hou.hipFile.isLoadingHipFile():
     on_duplicate()
+else:
+    hda_module.ensure_loader_expression_parm_defaults(node)

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/PythonModule
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/PythonModule
@@ -6,5 +6,6 @@ from ayon_houdini.api.hda_utils import (
     get_available_versions,
     select_product_name,
     set_to_latest_version,
-    expression_clear_cache
+    expression_clear_cache,
+    ensure_loader_expression_parm_defaults
 )

--- a/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/OnLoaded
+++ b/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/OnLoaded
@@ -12,3 +12,5 @@ def on_duplicate():
 
 if not hou.hipFile.isLoadingHipFile():
     on_duplicate()
+else:
+    hda_module.ensure_loader_expression_parm_defaults(node)

--- a/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/PythonModule
+++ b/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/PythonModule
@@ -6,5 +6,6 @@ from ayon_houdini.api.hda_utils import (
     get_available_versions,
     select_product_name,
     set_to_latest_version,
-    expression_clear_cache
+    expression_clear_cache,
+    ensure_loader_expression_parm_defaults
 )


### PR DESCRIPTION
## Changelog Description

Fix old LOP loaders missing the file/representation parm expressions due to having explicit attribute value overrides

## Additional review information

Before the loaders used explicit parm callbacks to set the filepath and representation id on the nodes. As such, these attributes had "overrides" from their default values - lacking the default expressions. This PR, ensures those parameter expressions are 'reverted' on update.

This will fix through the scene inventory, if e.g. the user broke it actively and then trigger UPDATE once via the loader itself to get the support for changing versions on the nodes directly again.

However, it also fixes existing loaders on scene open.

## Testing notes:
Either:
1. Set up Load Asset LOP or Load Shot LOP
2. Explicitly break the `file` or `representation` parm expressions.

Or:
1.  Open a legacy scene with loaders from before the change to expressions PR

Then:
1. Update via scene inventory

The node should be updated.