### PR TITLE
Add `stagingDir` to `usdrender` product

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -68,6 +68,8 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
             dirname = os.path.dirname(name)
             basename = os.path.basename(name)
 
+            instance.data["stagingDir"] = dirname
+
             dollarf_regex = r"(\$F([0-9]?))"
             if re.match(dollarf_regex, basename):
                 # TODO: Confirm this actually is allowed USD stages and HUSK


### PR DESCRIPTION
## Changelog Description
needed for `ExtractSkeletonPinningJSON` to work as it expects `usdrender` instances to have `stagingDir`, check it [here](https://github.com/ynput/ayon-usd/blob/4f52045f564bb5c877aee15ff02fa456ea53f1dd/client/ayon_usd/plugins/publish/extract_skeleton_pinning_json.py#L57-L65).

## Additional Info
This PR is exactly the same as https://github.com/ynput/ayon-houdini/pull/157 excluding the style changes. 


## Testing notes:
1. Checkout this PR and https://github.com/ynput/ayon-usd/pull/76
2. publishing `usdrender` should be okay.
