### PR TITLE
Bugfix: Farm cache publish support newer ayon-deadline versions

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -46,25 +46,23 @@ class CollectDataforCache(plugin.HoudiniInstancePlugin):
         ropnode = hou.node(instance.data["instance_node"])
         output_parm = lib.get_output_parameter(ropnode)
         expected_filepath = output_parm.eval()
-        instance.data.setdefault("files", list())
-        instance.data.setdefault("expectedFiles", list())
 
+        files = instance.data.setdefault("files", list())
         frames = instance.data.get("frames", "")
         if isinstance(frames, str):
             # single file
-            instance.data["files"].append(expected_filepath)
+            files.append(expected_filepath)
         else:
             # list of files
             staging_dir, _ = os.path.split(expected_filepath)
-            instance.data["files"].extend(
-                ["{}/{}".format(staging_dir, f) for f in frames]
-            )
+            files.extend("{}/{}".format(staging_dir, f) for f in frames)
 
-        cache_files = {"cache": instance.data["files"]}
+        expected_files = instance.data.setdefault("expectedFiles", list())
+        expected_files.append({"cache": files})
+        self.log.debug(f"Caching on farm expected files: {expected_files}")
 
         instance.data.update({
+             # used in HoudiniCacheSubmitDeadline in ayon-deadline
             "plugin": "Houdini",
             "publish": True
         })
-        instance.data["expectedFiles"].append(cache_files)
-        self.log.debug("Caching on farm expected files: {}".format(instance.data["expectedFiles"]))

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -9,7 +9,7 @@ from ayon_houdini.api import (
 
 class CollectFarmCacheFamily(plugin.HoudiniInstancePlugin):
     """Collect publish.hou family for caching on farm as early as possible."""
-    order = pyblish.api.CollectorOrder - 0.5
+    order = pyblish.api.CollectorOrder - 0.45
     families = ["ass", "pointcache", "redshiftproxy", "vdbcache", "model"]
     targets = ["local", "remote"]
     label = "Collect Data for Cache"

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -7,11 +7,9 @@ from ayon_houdini.api import (
 )
 
 
-class CollectDataforCache(plugin.HoudiniInstancePlugin):
-    """Collect data for caching to Deadline."""
-
-    # Run after Collect Frames
-    order = pyblish.api.CollectorOrder + 0.11
+class CollectFarmCacheFamily(plugin.HoudiniInstancePlugin):
+    """Collect publish.hou family for caching on farm as early as possible."""
+    order = pyblish.api.CollectorOrder - 0.5
     families = ["ass", "pointcache", "redshiftproxy", "vdbcache", "model"]
     targets = ["local", "remote"]
     label = "Collect Data for Cache"
@@ -24,6 +22,19 @@ class CollectDataforCache(plugin.HoudiniInstancePlugin):
             self.log.debug("Caching on farm is disabled. "
                            "Skipping farm collecting.")
             return
+        instance.data["families"].append("publish.hou")
+
+
+class CollectDataforCache(plugin.HoudiniInstancePlugin):
+    """Collect data for caching to Deadline."""
+
+    # Run after Collect Frames
+    order = pyblish.api.CollectorOrder + 0.11
+    families = ["publish.hou"]
+    targets = ["local", "remote"]
+    label = "Collect Data for Cache"
+
+    def process(self, instance):
         # Why do we need this particular collector to collect the expected
         # output files from a ROP node. Don't we have a dedicated collector
         # for that yet?
@@ -55,7 +66,5 @@ class CollectDataforCache(plugin.HoudiniInstancePlugin):
             "plugin": "Houdini",
             "publish": True
         })
-        instance.data["families"].append("publish.hou")
         instance.data["expectedFiles"].append(cache_files)
-
         self.log.debug("Caching on farm expected files: {}".format(instance.data["expectedFiles"]))


### PR DESCRIPTION
## Changelog Description

Set the `publish.hou` family much earlier to avoid issues with `ayon-deadline` plug-ins that were ordered earlier than how we set it before this PR in `ayon-houdini`.

## Additional review information

Fixes #138

## Testing notes:

1. Use latest ayon-deadline
2. Publish farm cache
3. Should work