### PR TITLE
Do not error on Load Warnings, but instead just log them.

### DIFF
--- a/client/ayon_houdini/api/pipeline.py
+++ b/client/ayon_houdini/api/pipeline.py
@@ -112,9 +112,12 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # Force forwards slashes to avoid segfault
         filepath = filepath.replace("\\", "/")
 
-        hou.hipFile.load(filepath,
-                         suppress_save_prompt=True,
-                         ignore_load_warnings=False)
+        try:
+            hou.hipFile.load(filepath,
+                             suppress_save_prompt=True,
+                             ignore_load_warnings=False)
+        except hou.LoadWarning as exc:
+            log.warning(exc)
 
         return filepath
 


### PR DESCRIPTION
## Changelog Description

Do not error on Load Warnings, but instead just log them.

- This allows the workfiles tool to not show a red "Failed to open workfile" message if the scene just opened with warnings.
- Also avoids errors in "open_workfile" from headless mode if the file did open, but just had warnings

## Additional review information

Instead of showing an error pop-up scene warnings like:
```
Skipping unrecognized parameter "load_refresh".
Skipping unrecognized parameter "load_message".             
```
Will now just be logged instead of prompted to the user.

## Testing notes:

1. Open scene with HDA that has changed in the meantime (e.g. has parameters removed that were previously overridden in the existing file)