### PR TITLE
Render: Validate render product paths are unique between instances

### DIFF
--- a/client/ayon_houdini/api/action.py
+++ b/client/ayon_houdini/api/action.py
@@ -35,9 +35,6 @@ class SelectInvalidAction(pyblish.api.Action):
                         self.log.warning("Plug-in returned to be invalid, "
                                          "but has no selectable nodes.")
 
-        errored_instances = get_errored_instances_from_context(context,
-                                                               plugin=plugin)
-
         hou.clearAllSelected()
         if invalid:
             self.log.info("Selecting invalid nodes: {}".format(

--- a/client/ayon_houdini/api/action.py
+++ b/client/ayon_houdini/api/action.py
@@ -17,20 +17,26 @@ class SelectInvalidAction(pyblish.api.Action):
 
     def process(self, context, plugin):
 
-        errored_instances = get_errored_instances_from_context(context,
-                                                               plugin=plugin)
-
         # Get the invalid nodes for the plug-ins
         self.log.info("Finding invalid nodes..")
         invalid = list()
-        for instance in errored_instances:
-            invalid_nodes = plugin.get_invalid(instance)
-            if invalid_nodes:
-                if isinstance(invalid_nodes, (list, tuple)):
-                    invalid.extend(invalid_nodes)
-                else:
-                    self.log.warning("Plug-in returned to be invalid, "
-                                     "but has no selectable nodes.")
+        if issubclass(plugin, pyblish.api.ContextPlugin):
+            invalid = plugin.get_invalid(context)
+        else:
+            errored_instances = get_errored_instances_from_context(
+                context, plugin=plugin
+            )
+            for instance in errored_instances:
+                invalid_nodes = plugin.get_invalid(instance)
+                if invalid_nodes:
+                    if isinstance(invalid_nodes, (list, tuple)):
+                        invalid.extend(invalid_nodes)
+                    else:
+                        self.log.warning("Plug-in returned to be invalid, "
+                                         "but has no selectable nodes.")
+
+        errored_instances = get_errored_instances_from_context(context,
+                                                               plugin=plugin)
 
         hou.clearAllSelected()
         if invalid:

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -1,0 +1,109 @@
+import inspect
+from collections import defaultdict
+from typing import List
+
+import pyblish.api
+import clique
+import hou
+
+from ayon_core.pipeline import (
+    OptionalPyblishPluginMixin,
+    PublishValidationError
+)
+
+from ayon_houdini.api import plugin
+from ayon_houdini.api.action import SelectInvalidAction
+
+
+class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
+                                       OptionalPyblishPluginMixin):
+    """Validate that render product paths are unique.
+
+    This allows to catch before rendering whether multiple render ROPs would
+    end up writing to the same filepaths. This can be a problem when rendering
+    because each render job would overwrite the files of the other at
+    rendertime.
+
+    """
+    order = pyblish.api.ValidatorOrder
+    families = ["usdrender"]
+    hosts = ["houdini"]
+    label = "Unique Render Product Paths"
+    actions = [SelectInvalidAction]
+    optional = True
+
+    def process(self, context):
+        if not self.is_active(context.data):
+            return
+
+        invalid = self.get_invalid(context)
+        if not invalid:
+            return
+
+        node_paths = [node.path() for node in invalid]
+        node_paths.sort()
+        invalid_list = "\n".join(f"- {path}" for path in node_paths)
+        raise PublishValidationError(
+            "Multiple instances render to the same path. "
+            "Please make sure each ROP renders to a unique output path:\n"
+            f"{invalid_list}",
+            title=self.label,
+            description=self.get_description()
+        )
+
+    @classmethod
+    def get_invalid(cls, context) -> "List[hou.Node]":
+        # Get instances matching this plugin families
+        instances = pyblish.api.instances_by_plugin(list(context), cls)
+        if len(instances) < 2:
+            return []
+
+        # Get expected rendered filepaths
+        paths_to_instance_id = defaultdict(list)
+        for instance in instances:
+            expected_files = instance.data.get("expectedFiles", [])
+            files_by_aov = expected_files[0]
+            for aov_name, aov_filepaths in files_by_aov.items():
+                for aov_filepath in aov_filepaths:
+                    paths_to_instance_id[aov_filepath].append(instance.id)
+
+        # Get invalid instances by instance.id
+        invalid_instance_ids = set()
+        invalid_paths = []
+        for path, path_instance_ids in paths_to_instance_id.items():
+            if len(path_instance_ids) > 1:
+                for path_instance_d in path_instance_ids:
+                    invalid_instance_ids.add(path_instance_d)
+                invalid_paths.append(path)
+
+        if not invalid_instance_ids:
+            return []
+
+        # Log invalid sequences as single collection
+        collections, remainder = clique.assemble(invalid_paths)
+        for collection in collections:
+            cls.log.warning(f"Multiple instances output to path: {collection}")
+        for path in remainder:
+            cls.log.warning(f"Multiple instances output to path: {path}")
+
+        # Get the invalid instances so we could also add a select action.
+        invalid = []
+        for instance in [
+            instance for instance in instances
+            if instance.id in invalid_instance_ids
+        ]:
+            node = hou.node(instance.data["instance_node"])
+            invalid.append(node)
+
+        return invalid
+
+    def get_description(self):
+        return inspect.cleandoc(
+            """### Output paths overwrite each other
+            
+            Multiple instances output to the same path. This can cause each
+            render to overwrite the other providing unexpected results.
+            
+            Update the output paths to be unique across all instances.
+            """
+        )

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -40,10 +40,8 @@ def get_instance_expected_files(instance: pyblish.api.Instance) -> List[str]:
             # single file.
             filepaths.append(f"{staging_dir}/{frames}")
         else:
-            # list of frame.
-            filepaths.extend(
-                [f"{staging_dir}/{frame}" for frame in frames]
-            )
+            # list of frames
+            filepaths.extend(f"{staging_dir}/{frame}" for frame in frames)
 
     return filepaths
 

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -101,7 +101,6 @@ class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
         paths_to_instance_id = defaultdict(list)
         for instance in instances:
             for filepath in get_instance_expected_files(instance):
-                cls.log.info(filepath)
                 paths_to_instance_id[filepath].append(instance.id)
 
         # Get invalid instances by instance.id

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -27,8 +27,8 @@ def get_instance_expected_files(instance: pyblish.api.Instance) -> List[str]:
         # Products with expected files
         # This can be Render products or submitted cache to farm.
         for expected in expected_files:
-            # expected.values() is a list of lists
-            filepaths.extend(expected.values())
+            for sequence_files in expected.values():
+                filepaths.extend(sequence_files)
     else:
         # Products with frames or single file.
         staging_dir = instance.data.get("stagingDir")
@@ -103,6 +103,7 @@ class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
         paths_to_instance_id = defaultdict(list)
         for instance in instances:
             for filepath in get_instance_expected_files(instance):
+                cls.log.info(filepath)
                 paths_to_instance_id[filepath].append(instance.id)
 
         # Get invalid instances by instance.id

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -100,6 +100,12 @@ class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
         # Get expected rendered filepaths
         paths_to_instance_id = defaultdict(list)
         for instance in instances:
+            # Skip the original instance when local rendering and those have
+            # created additional runtime instances per AOV. This avoids
+            # validating similar instances multiple times.
+            if not instance.data.get("integrate", True):
+                continue
+
             for filepath in get_instance_expected_files(instance):
                 paths_to_instance_id[filepath].append(instance.id)
 

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -94,7 +94,7 @@ class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
     def get_invalid(cls, context) -> "List[hou.Node]":
         # Get instances matching this plugin families
         instances = pyblish.api.instances_by_plugin(list(context), cls)
-        if len(instances) < 2:
+        if not instances:
             return []
 
         # Get expected rendered filepaths

--- a/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_product_paths_unique.py
@@ -147,5 +147,10 @@ class ValidateRenderProductPathsUnique(plugin.HoudiniContextPlugin,
             render to overwrite the other providing unexpected results.
             
             Update the output paths to be unique across all instances.
+            
+            It may be the case that a single instance outputs multiple files
+            that overwrite each other, like separate AOV outputs from one ROP.
+            In that case it may be necessary to update the individual AOV 
+            output paths, instead of outputs between separate instances.
             """
         )


### PR DESCRIPTION
## Changelog Description

Validate render product paths are unique between instances

## Additional review information

This is especially useful when setting up complex scenes with multi-shot workflows. The scene may have been misconfigured and not specify a unique output path for each ROP if there are many context options involved. This validation ensures all the expect render paths (in working area) are expected to be a unique path for each of the instances.

@MustafaJafar do you know if this same logic would for the other render families as well? If so, it may be nice to add those families to the validator too?

## Testing notes:
1. Set up two render ROPs with the same render path.
2. Publish both at the same time.
3. Validation should catch it.
