### PR TITLE
Allow `lopimportcam` for review

### DIFF
--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -63,7 +63,7 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
         if not camera_node:
             return "Camera path does not exist: '{}'".format(path)
         type_name = camera_node.type().name()
-        if type_name != "cam":
+        if type_name not in {"cam", "lopimportcam"}:
             return "Camera path is not a camera: '{}' (type: {})".format(
                 path, type_name
             )


### PR DESCRIPTION
## Changelog Description

Allow `lopimportcam` for review product type.

## Additional review information

Fixes #23

## Testing notes:

1. A camera imported with `lopimportcam` to `/obj` should also be allowed `review` publish.
2. Animated focal length on the camera in Solaris should come through correctly to the review burnin.