### PR TITLE
USD Render: prefix the AOV with the render product name

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -159,6 +159,11 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
         otherwise we'll assume renderproduct to be a combined multilayer
         'main' layer
 
+        Note:
+            Different products can export the same AOV but with different
+            configurations, such as Beauty and Deep Beauty.
+            Therefore, we prefix the AOV with the render product name.
+
         Args:
             render_product (pxr.UsdRender.Product): The Render Product
 
@@ -167,6 +172,7 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
 
         """
         targets = render_product.GetOrderedVarsRel().GetTargets()
+        render_product_name = render_product.GetPrim().GetName()
         if len(targets) > 1:
             # Cryptomattes usually are combined render vars, for example:
             # - crypto_asset, crypto_asset01, crypto_asset02, crypto_asset03
@@ -175,13 +181,13 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
             # e.g. `crypto_asset` or `crypto` (if multiple are combined)
             if all(target.name.startswith("crypto") for target in targets):
                 start = os.path.commonpath([target.name for target in targets])
-                return start.rstrip("_")  # remove any trailing _
+                return f"{render_product_name}.{start.rstrip('_')}"  # remove any trailing _
 
             # Main layer
-            return ""
+            return render_product_name
         elif len(targets) == 1:
             # AOV for a single var
-            return targets[0].name
+            return f"{render_product_name}.{targets[0].name}"
         else:
             self.log.warning(
                 f"Render product has no rendervars set: {render_product}")


### PR DESCRIPTION
## Changelog Description
prefix the AOV with the render product name.
Hopefully, resolve #105 

> [!Note]
> This PR was made to show the issue where different render products can export the same render var(AOV) but with different configurations, such as Beauty and Deep Beauty.
> In this essence, the publisher is not creating enough instances for them and just keep showing this error message: 
> ```
> Multiple render products are identified as the same AOV 
> which means one of the two will not be ingested during 
> publishing. AOV: '%s'", aov_identifier
> ```

> [!Important]
> For this PR to be merged, we need to ensure it's backwards compatible
> where the layers shouldn't get a new name or being too long and cluttered.

## Additional Info
Here's an example scene. Please let me now if it's not a good example scene.
[Expr_USD_Render_Houdini_v001.zip](https://github.com/user-attachments/files/17819731/Expr_USD_Render_Houdini_v001.zip)

## Demo
Here are some screenshots.

When Dcm has one AOV
![image](https://github.com/user-attachments/assets/a869a910-74df-442e-93bc-749578065f4c)

When Dcm has multiple AOVs
![image](https://github.com/user-attachments/assets/80112887-fdb0-47ff-b32a-e253d97dca0d)


## Testing notes:
1. Add multiple render vars and multiple products.
2. Feel free to us the same render var within different render products.
3. Publish USD render.
