### PR TITLE
Support render targets for cache instances

### DIFF
--- a/client/ayon_houdini/plugins/create/create_alembic_camera.py
+++ b/client/ayon_houdini/plugins/create/create_alembic_camera.py
@@ -2,6 +2,7 @@
 """Creator plugin for creating alembic camera products."""
 from ayon_houdini.api import plugin
 from ayon_core.pipeline import CreatorError
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -14,10 +15,16 @@ class CreateAlembicCamera(plugin.HoudiniCreator):
     product_type = "camera"
     icon = "camera"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
         instance_data.update({"node_type": "alembic"})
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateAlembicCamera, self).create(
             product_name,
@@ -54,3 +61,21 @@ class CreateAlembicCamera(plugin.HoudiniCreator):
             hou.ropNodeTypeCategory(),
             hou.objNodeTypeCategory()
         ]
+    
+    def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
+        return [
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
+        ]
+    
+    def get_pre_create_attr_defs(self):
+        attrs = super().get_pre_create_attr_defs()
+        return attrs + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_arnold_ass.py
+++ b/client/ayon_houdini/plugins/create/create_arnold_ass.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating Arnold ASS files."""
 from ayon_houdini.api import plugin
-from ayon_core.lib import BoolDef
+from ayon_core.lib import EnumDef
 
 
 class CreateArnoldAss(plugin.HoudiniCreator):
@@ -17,13 +17,16 @@ class CreateArnoldAss(plugin.HoudiniCreator):
     # will override it by the value in the project settings
     ext = ".ass"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
         instance_data.update({"node_type": "arnold"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateArnoldAss, self).create(
             product_name,
@@ -57,10 +60,17 @@ class CreateArnoldAss(plugin.HoudiniCreator):
         self.lock_parameters(instance_node, to_lock)
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -13,6 +13,9 @@ class CreateBGEO(plugin.HoudiniCreator):
     product_type = "pointcache"
     icon = "gears"
 
+    # Default render target
+    render_target = "local"
+
     def get_publish_families(self):
         return ["pointcache", "bgeo"]
 
@@ -21,7 +24,7 @@ class CreateBGEO(plugin.HoudiniCreator):
         instance_data.update({"node_type": "geometry"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateBGEO, self).create(
             product_name,
@@ -63,10 +66,17 @@ class CreateBGEO(plugin.HoudiniCreator):
         instance_node.setParms(parms)
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -3,7 +3,7 @@
 from ayon_houdini.api import plugin
 from ayon_core.pipeline import CreatorError
 import hou
-from ayon_core.lib import EnumDef, BoolDef
+from ayon_core.lib import EnumDef
 
 
 class CreateBGEO(plugin.HoudiniCreator):

--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -2,7 +2,6 @@
 """Creator plugin for creating composite sequences."""
 from ayon_houdini.api import plugin
 from ayon_core.pipeline import CreatorError
-from ayon_core.lib import EnumDef
 
 import hou
 
@@ -17,16 +16,10 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
 
     ext = ".exr"
 
-    # Default render target
-    render_target = "local"
-
     def create(self, product_name, instance_data, pre_create_data):
         import hou  # noqa
 
         instance_data.update({"node_type": "comp"})
-        creator_attributes = instance_data.setdefault(
-            "creator_attributes", dict())
-        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateCompositeSequence, self).create(
             product_name,
@@ -65,21 +58,3 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
             hou.ropNodeTypeCategory(),
             hou.cop2NodeTypeCategory()
         ]
-
-    def get_instance_attr_defs(self):
-        render_target_items = {
-            "local": "Local machine rendering",
-            "local_no_render": "Use existing frames (local)",
-            "farm": "Farm Rendering",
-        }
-
-        return [
-            EnumDef("render_target",
-                    items=render_target_items,
-                    label="Render target",
-                    default=self.render_target)
-        ]
-
-    def get_pre_create_attr_defs(self):
-        attrs = super().get_pre_create_attr_defs()
-        return attrs + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -2,6 +2,7 @@
 """Creator plugin for creating composite sequences."""
 from ayon_houdini.api import plugin
 from ayon_core.pipeline import CreatorError
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -16,10 +17,16 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
 
     ext = ".exr"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
         import hou  # noqa
 
         instance_data.update({"node_type": "comp"})
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateCompositeSequence, self).create(
             product_name,
@@ -58,3 +65,21 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
             hou.ropNodeTypeCategory(),
             hou.cop2NodeTypeCategory()
         ]
+
+    def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
+        return [
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
+        ]
+
+    def get_pre_create_attr_defs(self):
+        attrs = super().get_pre_create_attr_defs()
+        return attrs + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_model.py
+++ b/client/ayon_houdini/plugins/create/create_model.py
@@ -12,7 +12,7 @@ Note:
 """
 
 from ayon_houdini.api import plugin
-from ayon_core.lib import BoolDef
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -24,6 +24,9 @@ class CreateModel(plugin.HoudiniCreator):
     product_type = "model"
     icon = "cube"
 
+    # Default render target
+    render_target = "local"
+
     def get_publish_families(self):
         return ["model", "abc"]
 
@@ -31,7 +34,7 @@ class CreateModel(plugin.HoudiniCreator):
         instance_data.update({"node_type": "alembic"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateModel, self).create(
             product_name,
@@ -130,10 +133,17 @@ class CreateModel(plugin.HoudiniCreator):
                        key=lambda node: node.evalParm('outputidx'))
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_pointcache.py
+++ b/client/ayon_houdini/plugins/create/create_pointcache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating pointcache alembics."""
 from ayon_houdini.api import plugin
-from ayon_core.lib import BoolDef
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -14,6 +14,9 @@ class CreatePointCache(plugin.HoudiniCreator):
     product_type = "pointcache"
     icon = "gears"
 
+    # Default render target
+    render_target = "local"
+
     def get_publish_families(self):
         return ["pointcache", "abc"]
     
@@ -21,7 +24,7 @@ class CreatePointCache(plugin.HoudiniCreator):
         instance_data.update({"node_type": "alembic"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreatePointCache, self).create(
             product_name,
@@ -114,10 +117,17 @@ class CreatePointCache(plugin.HoudiniCreator):
                        key=lambda node: node.evalParm('outputidx'))
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_proxy.py
@@ -2,7 +2,7 @@
 """Creator plugin for creating Redshift proxies."""
 from ayon_houdini.api import plugin
 import hou
-from ayon_core.lib import BoolDef
+from ayon_core.lib import EnumDef
 
 
 class CreateRedshiftProxy(plugin.HoudiniCreator):
@@ -11,6 +11,9 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
     label = "Redshift Proxy"
     product_type = "redshiftproxy"
     icon = "magic"
+
+    # Default render target
+    render_target = "local"
 
     def create(self, product_name, instance_data, pre_create_data):
 
@@ -24,7 +27,7 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
         instance_data.update({"node_type": "Redshift_Proxy_Output"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateRedshiftProxy, self).create(
             product_name,
@@ -53,10 +56,17 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
         ]
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/create/create_review.py
+++ b/client/ayon_houdini/plugins/create/create_review.py
@@ -16,6 +16,9 @@ class CreateReview(plugin.HoudiniCreator):
     icon = "video-camera"
     review_color_space = ""
     node_type = "opengl"
+
+    # Default render target
+    render_target = "local"
     
     # TODO: Publish families should reflect the node type, 
     # such as `rop.flipbook` for flipbook nodes 
@@ -35,6 +38,9 @@ class CreateReview(plugin.HoudiniCreator):
     def create(self, product_name, instance_data, pre_create_data):
         
         self.node_type = pre_create_data.get("node_type")
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance_data.update({"node_type": self.node_type})
         instance_data["imageFormat"] = pre_create_data.get("imageFormat")
@@ -121,9 +127,23 @@ class CreateReview(plugin.HoudiniCreator):
         to_lock = ["id", "productType"]
 
         self.lock_parameters(instance_node, to_lock)
+    
+    def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
 
+        return [
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
+        ]
+    
     def get_pre_create_attr_defs(self):
-        attrs = super(CreateReview, self).get_pre_create_attr_defs()
+        attrs = super().get_pre_create_attr_defs()
 
         image_format_enum = [
             "bmp", "cin", "exr", "jpg", "pic", "pic.gz", "png",
@@ -165,4 +185,4 @@ class CreateReview(plugin.HoudiniCreator):
                       default=1.0,
                       minimum=0.0001,
                       decimals=3)
-        ]
+        ] + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating USDs."""
 from ayon_houdini.api import plugin
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -14,9 +15,15 @@ class CreateUSD(plugin.HoudiniCreator):
     enabled = False
     description = "Create USD"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
 
         instance_data.update({"node_type": "usd"})
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateUSD, self).create(
             product_name,
@@ -52,3 +59,21 @@ class CreateUSD(plugin.HoudiniCreator):
 
     def get_publish_families(self):
         return ["usd", "usdrop"]
+
+    def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
+        return [
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
+        ]
+    
+    def get_pre_create_attr_defs(self):
+        attrs = super().get_pre_create_attr_defs()
+        return attrs + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_usd_look.py
+++ b/client/ayon_houdini/plugins/create/create_usd_look.py
@@ -3,6 +3,7 @@
 import inspect
 
 from ayon_houdini.api import plugin
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -17,9 +18,15 @@ class CreateUSDLook(plugin.HoudiniCreator):
     enabled = True
     description = "Create USD Look"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
 
         instance_data.update({"node_type": "usd"})
+        creator_attributes = instance_data.setdefault(
+            "creator_attributes", dict())
+        creator_attributes["render_target"] = pre_create_data["render_target"]
 
         instance = super(CreateUSDLook, self).create(
             product_name,
@@ -70,3 +77,21 @@ class CreateUSDLook(plugin.HoudiniCreator):
 
     def get_publish_families(self):
         return ["usd", "look", "usdrop"]
+
+    def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
+        return [
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
+        ]
+    
+    def get_pre_create_attr_defs(self):
+        attrs = super().get_pre_create_attr_defs()
+        return attrs + self.get_instance_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_vbd_cache.py
+++ b/client/ayon_houdini/plugins/create/create_vbd_cache.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Creator plugin for creating VDB Caches."""
 from ayon_houdini.api import plugin
-from ayon_core.lib import BoolDef
+from ayon_core.lib import EnumDef
 
 import hou
 
@@ -14,13 +14,16 @@ class CreateVDBCache(plugin.HoudiniCreator):
     product_type = "vdbcache"
     icon = "cloud"
 
+    # Default render target
+    render_target = "local"
+
     def create(self, product_name, instance_data, pre_create_data):
         import hou
 
         instance_data.update({"node_type": "geometry"})
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
-        creator_attributes["farm"] = pre_create_data["farm"]
+        creator_attributes["render_target"] = pre_create_data["render_target"]
         instance = super(CreateVDBCache, self).create(
             product_name,
             instance_data,
@@ -109,10 +112,17 @@ class CreateVDBCache(plugin.HoudiniCreator):
                        key=lambda node: node.evalParm('outputidx'))
 
     def get_instance_attr_defs(self):
+        render_target_items = {
+            "local": "Local machine rendering",
+            "local_no_render": "Use existing frames (local)",
+            "farm": "Farm Rendering",
+        }
+
         return [
-            BoolDef("farm",
-                    label="Submitting to Farm",
-                    default=False)
+            EnumDef("render_target",
+                    items=render_target_items,
+                    label="Render target",
+                    default=self.render_target)
         ]
 
     def get_pre_create_attr_defs(self):

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -10,15 +10,13 @@ from ayon_houdini.api import (
 class CollectFarmCacheFamily(plugin.HoudiniInstancePlugin):
     """Collect publish.hou family for caching on farm as early as possible."""
     order = pyblish.api.CollectorOrder - 0.45
-    families = ["ass", "pointcache", "redshiftproxy", "vdbcache", "model"]
+    families = ["ass", "pointcache", "redshiftproxy",
+                "vdbcache", "model", "staticMesh",
+                 "rop.opengl", "usdrop", "camera"]
     targets = ["local", "remote"]
     label = "Collect Data for Cache"
 
     def process(self, instance):
-        creator_attribute = instance.data["creator_attributes"]
-        farm_enabled = creator_attribute.get("farm")
-        if farm_enabled is not None:
-            instance.data["farm"] = farm_enabled
 
         if not instance.data["farm"]:
             self.log.debug("Caching on farm is disabled. "

--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -16,9 +16,11 @@ class CollectFarmCacheFamily(plugin.HoudiniInstancePlugin):
 
     def process(self, instance):
         creator_attribute = instance.data["creator_attributes"]
-        farm_enabled = creator_attribute["farm"]
-        instance.data["farm"] = farm_enabled
-        if not farm_enabled:
+        farm_enabled = creator_attribute.get("farm")
+        if farm_enabled is not None:
+            instance.data["farm"] = farm_enabled
+
+        if not instance.data["farm"]:
             self.log.debug("Caching on farm is disabled. "
                            "Skipping farm collecting.")
             return

--- a/client/ayon_houdini/plugins/publish/collect_farm_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_farm_instances.py
@@ -12,7 +12,9 @@ class CollectFarmInstances(plugin.HoudiniInstancePlugin):
                 "arnold_rop",
                 "vray_rop",
                 "usdrender",
-                "bgeo"]
+                "ass","pointcache", "redshiftproxy",
+                "vdbcache", "model", "staticMesh",
+                "rop.opengl", "usdrop", "camera"]
 
     targets = ["local", "remote"]
     label = "Collect farm instances"

--- a/client/ayon_houdini/plugins/publish/collect_farm_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_farm_instances.py
@@ -5,13 +5,14 @@ from ayon_houdini.api import plugin
 class CollectFarmInstances(plugin.HoudiniInstancePlugin):
     """Collect instances for farm render."""
 
-    order = pyblish.api.CollectorOrder
+    order = pyblish.api.CollectorOrder - 0.49
     families = ["mantra_rop",
                 "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
                 "vray_rop",
-                "usdrender"]
+                "usdrender",
+                "bgeo"]
 
     targets = ["local", "remote"]
     label = "Collect farm instances"

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -19,6 +19,7 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         if instance.data.get("farm"):
             self.log.debug("Should be processed on farm, skipping.")
             return
+        creator_attribute = instance.data["creator_attributes"]
 
         files = instance.data["frames"]
         first_file = files[0] if isinstance(files, (list, tuple)) else files
@@ -29,7 +30,8 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
-        self.render_rop(instance)
+        if creator_attribute.get("render_target") in {None, "local"}:
+            self.render_rop(instance)
         self.validate_expected_frames(instance)
 
         # In some cases representation name is not the the extension

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -30,6 +30,9 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
+        # Value `local` is used as a fallback if the `render_target` key is missing.
+        # This key might be absent because render targets are not yet implemented
+        #  for all product types that use this plugin.
         if creator_attribute.get("render_target", "local") == "local":
             self.render_rop(instance)
         self.validate_expected_frames(instance)

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -30,7 +30,7 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
         )
         ext = ext.lstrip(".")
 
-        if creator_attribute.get("render_target") in {None, "local"}:
+        if creator_attribute.get("render_target", "local") == "local":
             self.render_rop(instance)
         self.validate_expected_frames(instance)
 


### PR DESCRIPTION
## Changelog Description
resolve #19 
Support render targets for the following products: (I'll add them by creators)
- Alembic camera
- Arnold ass 
- Pointcache Bgeo
- Model
- Pointcache Abc
- Redshift proxy
- Review
- Static Mesh
- USD (it works with contribution workflow. users should wait the publish before loading the usd asset)
- USD Look (it works with contribution workflow, users should wait the publish before loading the usd asset))
- VDB Cache

> [!Note]
> When supporting render targets for Houdini `CompositeSequence` (Cop Node), composite instances triggers `Submit Image Publishing job to Deadline` along `Submit cache jobs to Deadline` because the instance has both `imagesequence` and `publish.hou` families.
> Here's an issue for it https://github.com/ynput/ayon-houdini/issues/183

This means that supporting Cop Nodes will need to go through the render submitting logic instead of cache submitting logic.
![image](https://github.com/user-attachments/assets/cd9c431d-83f1-4eb4-9252-ef2b6cd8fc08)



## Testing notes:
1. Try publishing different cache instances with different render targets

