### PR TITLE
Containerise and parse container with `project_name` parm

### DIFF
--- a/client/ayon_houdini/api/pipeline.py
+++ b/client/ayon_houdini/api/pipeline.py
@@ -243,6 +243,7 @@ def containerise(name,
         "namespace": namespace,
         "loader": str(loader),
         "representation": context["representation"]["id"],
+        "project_name": context["project"]["name"]
     }
 
     lib.imprint(container, data)
@@ -284,6 +285,13 @@ def parse_container(container):
                 # not a json
                 pass
         data[name] = value
+
+    # Support project name in container as optional attribute
+    for name in ["project_name"]:
+        parm = container.parm(name)
+        if not parm:
+            continue
+        data[name] = parm.eval()
 
     # Backwards compatibility pre-schemas for containers
     data["schema"] = data.get("schema", "openpype:container-1.0")


### PR DESCRIPTION
## Changelog Description

Support loading containers with project name from another project - to allow managing loaded products from e.g. library project

## Additional review information

Requires https://github.com/ynput/ayon-core/pull/1005

## Testing notes:
1. Load products from Library Project
2. They should appear fine in scene inventory and should be updatable.
3. Load Asset LOP, Generic Loader, etc. should also work with this (and be updatable via scene inventory).
