### PR TITLE
User friendly error messages

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -5,6 +5,7 @@ import errno
 import re
 import logging
 import json
+import clique
 from contextlib import contextmanager
 
 import six
@@ -1596,3 +1597,10 @@ def connect_file_parm_to_loader(file_parm: hou.Parm):
         f' {file_parm.node().path()} {file_parm.name()} \`{expression}\`'
     )
     show_node_parmeditor(load_node)
+
+
+def format_as_collections(files: list[str], pattern: str = "{head}{padding}{tail} [{ranges}]") -> list[str]:
+    collections, remainder = clique.assemble(files)
+    result = [collection.format(pattern) for collection in collections]
+    result.extend(remainder)
+    return result

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1600,6 +1600,8 @@ def connect_file_parm_to_loader(file_parm: hou.Parm):
 
 
 def format_as_collections(files: list[str], pattern: str = "{head}{padding}{tail} [{ranges}]") -> list[str]:
+    """Return list of files as formatted sequence collections."""
+    
     collections, remainder = clique.assemble(files)
     result = [collection.format(pattern) for collection in collections]
     result.extend(remainder)

--- a/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
+++ b/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
@@ -30,22 +30,23 @@ class CollectComponentBuilderLOPs(plugin.HoudiniInstancePlugin,
 
         node = hou.node(instance.data["instance_node"])
 
-        try:
-            node.cook(force=True)  # required to clear existing errors
-        except hou.Error as exc:
-            errors = node.errors()
-            if errors:
-                errors = "\n\n - ".join(errors)
-                raise PublishError(
-                    f"Failed to cook node: '{node.path()}'. Please fix it to proceed.",
-                    detail=f"{exc} \n\n - {errors}"
-                )
-
         # Render the component builder LOPs
         # TODO: Do we want this? or use existing frames? Usually a Collector
         #  should not 'extract' but in this case we need the resulting USD
         #  file.
+        node.cook(force=True)  # required to clear existing errors
         node.parm("execute").pressButton()
+
+        errors = node.errors()
+        if errors:
+            for error in errors:
+                self.log.error(error)
+            raise PublishError(
+                f"Failed to save to disk '{node.path()}'. "
+                "Please fix your scene to ensure it renders correctly "
+                "and re-publish. Check the log for more information."
+            )
+
         # Define the main asset usd file
         filepath = node.evalParm("lopoutput")
         representations = instance.data.setdefault("representations", [])

--- a/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
+++ b/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
@@ -30,23 +30,22 @@ class CollectComponentBuilderLOPs(plugin.HoudiniInstancePlugin,
 
         node = hou.node(instance.data["instance_node"])
 
-        # Render the component builder LOPs
-        # TODO: Do we want this? or use existing frames? Usually a Collector
-        #  should not 'extract' but in this case we need the resulting USD
-        #  file.
         try:
             node.cook(force=True)  # required to clear existing errors
-            node.parm("execute").pressButton()
-        except Exception as exc:
+        except hou.Error as exc:
             errors = node.errors()
             if errors:
                 errors = "\n\n - ".join(errors)
                 raise PublishError(
-                    "Failed to save to disk."
-                    f"Please fix node: '{node.path()}'",
+                    f"Failed to cook node: '{node.path()}'. Please fix it to proceed.",
                     detail=f"{exc} \n\n - {errors}"
                 )
 
+        # Render the component builder LOPs
+        # TODO: Do we want this? or use existing frames? Usually a Collector
+        #  should not 'extract' but in this case we need the resulting USD
+        #  file.
+        node.parm("execute").pressButton()
         # Define the main asset usd file
         filepath = node.evalParm("lopoutput")
         representations = instance.data.setdefault("representations", [])

--- a/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
+++ b/client/ayon_houdini/plugins/publish/collect_componentbuilder_lop.py
@@ -34,14 +34,18 @@ class CollectComponentBuilderLOPs(plugin.HoudiniInstancePlugin,
         # TODO: Do we want this? or use existing frames? Usually a Collector
         #  should not 'extract' but in this case we need the resulting USD
         #  file.
-        node.cook(force=True)  # required to clear existing errors
-        node.parm("execute").pressButton()
-
-        errors = node.errors()
-        if errors:
-            for error in errors:
-                self.log.error(error)
-            raise PublishError(f"Failed to save to disk '{node.path()}'")
+        try:
+            node.cook(force=True)  # required to clear existing errors
+            node.parm("execute").pressButton()
+        except Exception as exc:
+            errors = node.errors()
+            if errors:
+                errors = "\n\n - ".join(errors)
+                raise PublishError(
+                    "Failed to save to disk."
+                    f"Please fix node: '{node.path()}'",
+                    detail=f"{exc} \n\n - {errors}"
+                )
 
         # Define the main asset usd file
         filepath = node.evalParm("lopoutput")

--- a/client/ayon_houdini/plugins/publish/collect_output_node.py
+++ b/client/ayon_houdini/plugins/publish/collect_output_node.py
@@ -66,7 +66,8 @@ class CollectOutputSOPPath(plugin.HoudiniInstancePlugin):
 
         else:
             raise KnownPublishError(
-                "ROP node type '{}' is not supported.".format(node_type)
+                f"ROP node type '{node_type}' is not supported"
+                f" for product type '{instance.data['product_type']}'"
             )
 
         if not out_node:

--- a/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -110,7 +110,8 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
 
                 if "#" not in filename:
                     raise PublishError(
-                        f"Couldn't resolve render product name with frame number: {name}"
+                        "Couldn't resolve render product output file"
+                        f" '{name}' with frame number."
                     )
 
             filenames.append(filename)

--- a/client/ayon_houdini/plugins/publish/collect_render_products.py
+++ b/client/ayon_houdini/plugins/publish/collect_render_products.py
@@ -6,6 +6,7 @@ import pxr.UsdRender
 
 import pyblish.api
 
+from ayon_core.pipeline import PublishError
 from ayon_houdini.api import plugin
 from ayon_houdini.api.usd import (
     get_usd_render_rop_rendersettings
@@ -107,10 +108,10 @@ class CollectRenderProducts(plugin.HoudiniInstancePlugin):
                 filename = os.path.join(dirname, filename_base)
                 filename = filename.replace("\\", "/")
 
-            assert "#" in filename, (
-                "Couldn't resolve render product name "
-                "with frame number: %s" % name
-            )
+                if "#" not in filename:
+                    raise PublishError(
+                        f"Couldn't resolve render product name with frame number: {name}"
+                    )
 
             filenames.append(filename)
 

--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -4,6 +4,7 @@ import re
 
 import pyblish.api
 
+from ayon_core.pipeline import KnownPublishError
 from ayon_core.pipeline.create import get_product_name
 from ayon_houdini.api import plugin
 import ayon_houdini.api.usd as usdlib
@@ -27,8 +28,7 @@ def copy_instance_data(instance_src, instance_dest, attr):
             in the source instance's data.
 
     Raises:
-        KeyError: If the key does not exist on the source instance.
-        AssertionError: If a parent key already exists on the destination
+        KnownPublishError: If a parent key already exists on the destination
             instance but is not of the correct type (= is not a dict)
 
     """
@@ -43,7 +43,8 @@ def copy_instance_data(instance_src, instance_dest, attr):
         src_value = src_data[key]
         if i != len(key):
             dest_data = dest_data.setdefault(key, {})
-            assert isinstance(dest_data, dict), "Destination must be a dict"
+            if not isinstance(dest_data, dict):
+                raise KnownPublishError("Destination must be a dict")
             src_data = src_value
         else:
             # Last iteration - assign the value

--- a/client/ayon_houdini/plugins/publish/extract_hda.py
+++ b/client/ayon_houdini/plugins/publish/extract_hda.py
@@ -48,7 +48,8 @@ class ExtractHDA(plugin.HoudiniExtractorPlugin):
             parm_folder = parm_group.findFolder("Extra")
             if not parm_folder:
                 raise PublishError(
-                    f"Extra parm folder does not exist: {hda_node.path()}"
+                    f"Extra AYON parm folder does not exist on {hda_node.path()}\n\n"
+                    "Please select the node and create an HDA product from the publisher UI."
                 )
 
             # Remove `Extra` AYON parameters

--- a/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/client/ayon_houdini/plugins/publish/extract_render.py
@@ -6,6 +6,7 @@ import pyblish.api
 
 from ayon_core.pipeline import PublishError
 from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import format_as_collections
 
 
 class ExtractRender(plugin.HoudiniExtractorPlugin):
@@ -82,15 +83,13 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
             for frame in all_frames
             if not os.path.exists(frame)
         ]
-        missing_frames , _ = clique.assemble(
-            missing_frames,
-            patterns=[clique.PATTERNS["frames"]],
-            minimum_items=1
-        )
-        missing_frames = "\n - ".join(f"{sequence}" for sequence in missing_frames)
+
         if missing_frames:
+            # Combine collections for simpler logs of missing files
+            missing_frames  = format_as_collections(missing_frames)
+            missing_frames = "\n ".join(f"- {sequence}" for sequence in missing_frames)
             raise PublishError(
                 "Failed to complete render extraction.\n"
                 "Please render any missing output files.",
-                detail=f"Missing output files: \n - {missing_frames}"
+                detail=f"Missing output files: \n {missing_frames}"
             )

--- a/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/client/ayon_houdini/plugins/publish/extract_render.py
@@ -87,10 +87,10 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
             patterns=[clique.PATTERNS["frames"]],
             minimum_items=1
         )
-        missing_frames = "\n\n - ".join(f"{sequence}" for sequence in missing_frames)
+        missing_frames = "\n - ".join(f"{sequence}" for sequence in missing_frames)
         if missing_frames:
             raise PublishError(
                 "Failed to complete render extraction.\n"
                 "Please render any missing output files.",
-                detail=f"Missing output files: \n\n - {missing_frames}"
+                detail=f"Missing output files: \n - {missing_frames}"
             )

--- a/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/client/ayon_houdini/plugins/publish/extract_render.py
@@ -1,5 +1,4 @@
 import os
-import clique
 import hou
 
 import pyblish.api

--- a/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/client/ayon_houdini/plugins/publish/extract_render.py
@@ -3,6 +3,7 @@ import hou
 
 import pyblish.api
 
+from ayon_core.pipeline import PublishError
 from ayon_houdini.api import plugin
 
 
@@ -75,13 +76,14 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
                 all_frames.extend(value)
         # Check missing frames.
         # Frames won't exist if user cancels the render.
-        missing_frames = [
+        missing_frames = "\n\n - ".join(
             frame
             for frame in all_frames
             if not os.path.exists(frame)
-        ]
+        )
         if missing_frames:
-            # TODO: Use user friendly error reporting.
-            raise RuntimeError("Failed to complete render extraction. "
-                               "Missing output files: {}".format(
-                                   missing_frames))
+            raise PublishError(
+                "Failed to complete render extraction.\n"
+                "Please render any missing output files.",
+                detail=f"Missing output files: \n\n - {missing_frames}"
+            )

--- a/client/ayon_houdini/plugins/publish/extract_render.py
+++ b/client/ayon_houdini/plugins/publish/extract_render.py
@@ -1,4 +1,5 @@
 import os
+import clique
 import hou
 
 import pyblish.api
@@ -76,11 +77,17 @@ class ExtractRender(plugin.HoudiniExtractorPlugin):
                 all_frames.extend(value)
         # Check missing frames.
         # Frames won't exist if user cancels the render.
-        missing_frames = "\n\n - ".join(
+        missing_frames = [
             frame
             for frame in all_frames
             if not os.path.exists(frame)
+        ]
+        missing_frames , _ = clique.assemble(
+            missing_frames,
+            patterns=[clique.PATTERNS["frames"]],
+            minimum_items=1
         )
+        missing_frames = "\n\n - ".join(f"{sequence}" for sequence in missing_frames)
         if missing_frames:
             raise PublishError(
                 "Failed to complete render extraction.\n"

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -1,5 +1,4 @@
 import os
-import clique
 import pyblish.api
 
 from ayon_core.pipeline import publish, PublishError

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -1,4 +1,5 @@
 import os
+import clique
 import pyblish.api
 
 from ayon_core.pipeline import publish, PublishError
@@ -68,15 +69,22 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
             # Single frame
             filenames = [filenames]
 
-        missing_filenames = "\n\n - ".join(
-            filename for filename in filenames
-            if not os.path.isfile(os.path.join(staging_dir, filename))
+        missing_frames = []
+        for filename in filenames:
+            filename = os.path.join(staging_dir, filename)
+            if not os.path.isfile(filename):
+                missing_frames.append(filename)
+
+        missing_frames , _ = clique.assemble(
+            missing_frames,
+            patterns=[clique.PATTERNS["frames"]],
+            minimum_items=1
         )
-        if missing_filenames:
+        if missing_frames:
             raise PublishError(
                 "Failed to complete render extraction.\n"
                 "Please render any missing output files.",
-                detail=f"Missing output files: \n\n - {missing_filenames}"
+                detail=f"Missing output files: \n\n - {missing_frames[0]}"
             )
 
     def update_representation_data(self,

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -1,7 +1,7 @@
 import os
 import pyblish.api
 
-from ayon_core.pipeline import publish
+from ayon_core.pipeline import publish, PublishError
 from ayon_houdini.api import plugin
 from ayon_houdini.api.lib import splitext
 
@@ -68,12 +68,16 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
             # Single frame
             filenames = [filenames]
 
-        missing_filenames = [
+        missing_filenames = "\n\n - ".join(
             filename for filename in filenames
             if not os.path.isfile(os.path.join(staging_dir, filename))
-        ]
+        )
         if missing_filenames:
-            raise RuntimeError(f"Missing frames: {missing_filenames}")
+            raise PublishError(
+                "Failed to complete render extraction.\n"
+                "Please render any missing output files.",
+                detail=f"Missing output files: \n\n - {missing_filenames}"
+            )
 
     def update_representation_data(self,
                                    instance: pyblish.api.Instance,

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -84,7 +84,7 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
             raise PublishError(
                 "Failed to complete render extraction.\n"
                 "Please render any missing output files.",
-                detail=f"Missing output files: \n\n - {missing_frames[0]}"
+                detail=f"Missing output files: \n - {missing_frames[0]}"
             )
 
     def update_representation_data(self,

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -4,7 +4,7 @@ import pyblish.api
 
 from ayon_core.pipeline import publish, PublishError
 from ayon_houdini.api import plugin
-from ayon_houdini.api.lib import splitext
+from ayon_houdini.api.lib import splitext, format_as_collections
 
 
 class ExtractROP(plugin.HoudiniExtractorPlugin):
@@ -75,16 +75,14 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
             if not os.path.isfile(filename):
                 missing_frames.append(filename)
 
-        missing_frames , _ = clique.assemble(
-            missing_frames,
-            patterns=[clique.PATTERNS["frames"]],
-            minimum_items=1
-        )
         if missing_frames:
+            # Combine collections for simpler logs of missing files
+            missing_frames  = format_as_collections(missing_frames)
+            missing_frames = "\n ".join(f"- {sequence}" for sequence in missing_frames)
             raise PublishError(
                 "Failed to complete render extraction.\n"
                 "Please render any missing output files.",
-                detail=f"Missing output files: \n - {missing_frames[0]}"
+                detail=f"Missing output files: \n {missing_frames}"
             )
 
     def update_representation_data(self,

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -3,7 +3,7 @@ from typing import List, AnyStr
 
 import pyblish.api
 
-from ayon_core.pipeline import KnownPublisherError, PublishError
+from ayon_core.pipeline import KnownPublishError, PublishError
 from ayon_core.pipeline.entity_uri import construct_ayon_entity_uri
 from ayon_core.pipeline.publish.lib import get_instance_expected_output_path
 from ayon_houdini.api import plugin
@@ -137,6 +137,6 @@ def get_source_paths(
         # Single file
         return [os.path.join(staging, files)]
 
-    raise KnownPublisherError(
+    raise KnownPublishError(
         f"Unsupported type for representation files: {files} (supports list or str)"
     )

--- a/client/ayon_houdini/plugins/publish/extract_usd.py
+++ b/client/ayon_houdini/plugins/publish/extract_usd.py
@@ -3,6 +3,7 @@ from typing import List, AnyStr
 
 import pyblish.api
 
+from ayon_core.pipeline import KnownPublisherError, PublishError
 from ayon_core.pipeline.entity_uri import construct_ayon_entity_uri
 from ayon_core.pipeline.publish.lib import get_instance_expected_output_path
 from ayon_houdini.api import plugin
@@ -47,7 +48,8 @@ class ExtractUSD(plugin.HoudiniExtractorPlugin):
         with remap_paths(ropnode, mapping):
             render_rop(ropnode)
 
-        assert os.path.exists(output), "Output does not exist: %s" % output
+        if not os.path.exists(output):
+            PublishError(f"Output does not exist: {output}")
 
         if "representations" not in instance.data:
             instance.data["representations"] = []
@@ -135,5 +137,6 @@ def get_source_paths(
         # Single file
         return [os.path.join(staging, files)]
 
-    raise TypeError(f"Unsupported type for representation files: {files} "
-                    "(supports list or str)")
+    raise KnownPublisherError(
+        f"Unsupported type for representation files: {files} (supports list or str)"
+    )

--- a/client/ayon_houdini/plugins/publish/increment_current_file.py
+++ b/client/ayon_houdini/plugins/publish/increment_current_file.py
@@ -42,7 +42,7 @@ class IncrementCurrentFile(plugin.HoudiniContextPlugin):
                 "submission to deadline failed."
             )
 
-        # Filename must not have changed since extraction.
+        # Filename must not have changed since collecting.
         host = registered_host()
         current_file = host.current_file()
         if context.data["currentFile"] != current_file:

--- a/client/ayon_houdini/plugins/publish/increment_current_file.py
+++ b/client/ayon_houdini/plugins/publish/increment_current_file.py
@@ -1,7 +1,7 @@
 import pyblish.api
 
 from ayon_core.lib import version_up
-from ayon_core.pipeline import registered_host
+from ayon_core.pipeline import registered_host, PublishError
 from ayon_core.pipeline.publish import (
     get_errored_plugins_from_context,
     KnownPublishError
@@ -46,8 +46,10 @@ class IncrementCurrentFile(plugin.HoudiniContextPlugin):
         host = registered_host()
         current_file = host.current_file()
         if context.data["currentFile"] != current_file:
-            raise KnownPublishError(
-                "Collected filename mismatches from current scene name."
+            raise PublishError(
+                f"Collected filename '{context.data['currentFile']}'"
+                f" mismatches from current scene name '{current_file}'."
+                "Save the file and republish. Don't change the file during publishing."
             )
 
         new_filepath = version_up(current_file)

--- a/client/ayon_houdini/plugins/publish/increment_current_file.py
+++ b/client/ayon_houdini/plugins/publish/increment_current_file.py
@@ -1,11 +1,9 @@
-import inspect
 import pyblish.api
 
 from ayon_core.lib import version_up
 from ayon_core.pipeline import (
     registered_host,
-    KnownPublishError,
-    PublishError
+    KnownPublishError
 )
 from ayon_core.pipeline.publish import get_errored_plugins_from_context
 
@@ -44,23 +42,14 @@ class IncrementCurrentFile(plugin.HoudiniContextPlugin):
                 "submission to deadline failed."
             )
 
-        # Filename must not have changed since collecting
+        # Filename must not have changed since extraction.
         host = registered_host()
         current_file = host.current_file()
         if context.data["currentFile"] != current_file:
-            raise PublishError(
+            raise KnownPublishError(
                 f"Collected filename '{context.data['currentFile']}' differs"
-                f" from current scene name '{current_file}'.",
-                description=self.get_error_description()
+                f" from current scene name '{current_file}'."
             )
 
         new_filepath = version_up(current_file)
         host.save_workfile(new_filepath)
-
-    def get_error_description(self):
-        return inspect.cleandoc(
-            """### Scene File Name Change During Publishing
-            This error occurs when you validate the scene and then save it as a new file manually, or if you open a new file and continue publishing.
-            Please reset the publisher and publish without changing the scene file midway.
-            """
-        )

--- a/client/ayon_houdini/plugins/publish/save_scene.py
+++ b/client/ayon_houdini/plugins/publish/save_scene.py
@@ -1,6 +1,7 @@
+import inspect
 import pyblish.api
 
-from ayon_core.pipeline import registered_host
+from ayon_core.pipeline import registered_host, PublishError
 
 from ayon_houdini.api import plugin
 
@@ -16,12 +17,23 @@ class SaveCurrentScene(plugin.HoudiniContextPlugin):
         # Filename must not have changed since collecting
         host = registered_host()
         current_file = host.get_current_workfile()
-        assert context.data['currentFile'] == current_file, (
-            "Collected filename from current scene name."
-        )
-
+        if context.data['currentFile'] != current_file:
+            raise PublishError(
+                f"Collected filename '{context.data['currentFile']}' differs"
+                f" from current scene name '{current_file}'.",
+                description=self.get_error_description()
+            )
         if host.workfile_has_unsaved_changes():
             self.log.info("Saving current file: {}".format(current_file))
             host.save_workfile(current_file)
         else:
             self.log.debug("No unsaved changes, skipping file save..")
+
+
+    def get_error_description(self):
+        return inspect.cleandoc(
+            """### Scene File Name Change During Publishing
+            This error occurs when you validate the scene and then save it as a new file manually, or if you open a new file and continue publishing.
+            Please reset the publisher and publish without changing the scene file midway.
+            """
+        )

--- a/client/ayon_houdini/plugins/publish/save_scene.py
+++ b/client/ayon_houdini/plugins/publish/save_scene.py
@@ -32,7 +32,7 @@ class SaveCurrentScene(plugin.HoudiniContextPlugin):
 
     def get_error_description(self):
         return inspect.cleandoc(
-            """### Scene File Name Change During Publishing
+            """### Scene File Name Changed During Publishing
             This error occurs when you validate the scene and then save it as a new file manually, or if you open a new file and continue publishing.
             Please reset the publisher and publish without changing the scene file midway.
             """

--- a/client/ayon_houdini/plugins/publish/validate_abc_primitive_to_detail.py
+++ b/client/ayon_houdini/plugins/publish/validate_abc_primitive_to_detail.py
@@ -26,9 +26,12 @@ class ValidateAbcPrimitiveToDetail(plugin.HoudiniInstancePlugin):
         invalid = self.get_invalid(instance)
         if invalid:
             raise PublishValidationError(
-                ("Primitives found with inconsistent primitive "
-                 "to detail attributes. See log."),
-                title=self.label
+                "Primitives found with inconsistent primitive "
+                "to detail attributes.",
+                detail=(
+                    "See log for more info."
+                    f"Incorrect Rop(s)\n\n - {invalid[0].pah()}"
+                )
             )
 
     @classmethod

--- a/client/ayon_houdini/plugins/publish/validate_frame_token.py
+++ b/client/ayon_houdini/plugins/publish/validate_frame_token.py
@@ -43,11 +43,11 @@ class ValidateFrameToken(plugin.HoudiniInstancePlugin):
         # Check trange parm, 0 means Render Current Frame
         frame_range = node.evalParm("trange")
         if frame_range == 0:
-            return
+            return []
 
         output_parm = lib.get_output_parameter(node)
         unexpanded_str = output_parm.unexpandedString()
 
         if "$F" not in unexpanded_str:
             cls.log.error("No frame token found in '%s'" % node.path())
-            return [node]
+            return [instance]

--- a/client/ayon_houdini/plugins/publish/validate_frame_token.py
+++ b/client/ayon_houdini/plugins/publish/validate_frame_token.py
@@ -2,6 +2,7 @@ import hou
 
 import pyblish.api
 
+from ayon_core.pipeline import PublishValidationError
 from ayon_houdini.api import lib, plugin
 
 
@@ -31,7 +32,7 @@ class ValidateFrameToken(plugin.HoudiniInstancePlugin):
 
         invalid = self.get_invalid(instance)
         if invalid:
-            raise RuntimeError(
+            raise PublishValidationError(
                 "Output settings do no match for '%s'" % instance
             )
 
@@ -42,11 +43,11 @@ class ValidateFrameToken(plugin.HoudiniInstancePlugin):
         # Check trange parm, 0 means Render Current Frame
         frame_range = node.evalParm("trange")
         if frame_range == 0:
-            return []
+            return
 
         output_parm = lib.get_output_parameter(node)
         unexpanded_str = output_parm.unexpandedString()
 
         if "$F" not in unexpanded_str:
             cls.log.error("No frame token found in '%s'" % node.path())
-            return [instance]
+            return [node]

--- a/client/ayon_houdini/plugins/publish/validate_sop_output_node.py
+++ b/client/ayon_houdini/plugins/publish/validate_sop_output_node.py
@@ -33,8 +33,10 @@ class ValidateSopOutputNode(plugin.HoudiniInstancePlugin):
         invalid = self.get_invalid(instance)
         if invalid:
             raise PublishValidationError(
-                "Output node(s) are incorrect",
-                title="Invalid output node(s)"
+                "Output node(s) are incorrect.",
+                detail=(
+                    f"Incorrect output SOP path on Rop(s)\n\n - {invalid[0].path()}"
+                )
             )
 
     @classmethod
@@ -65,9 +67,9 @@ class ValidateSopOutputNode(plugin.HoudiniInstancePlugin):
         # the isinstance check above should be stricter than this category
         if output_node.type().category().name() != "Sop":
             raise PublishValidationError(
-                ("Output node {} is not of category Sop. "
-                 "This is a bug.").format(output_node.path()),
-                title=cls.label)
+                f"Output node {output_node.path()} is not of category Sop.",
+                title=cls.label
+            )
 
         # Ensure the node is cooked and succeeds to cook so we can correctly
         # check for its geometry data.
@@ -76,9 +78,10 @@ class ValidateSopOutputNode(plugin.HoudiniInstancePlugin):
             try:
                 output_node.cook()
             except hou.Error as exc:
-                cls.log.error("Cook failed: %s" % exc)
-                cls.log.error(output_node.errors()[0])
-                return [output_node]
+                raise PublishValidationError(
+                    f"Failed to cook node: {output_node.path()}.",
+                    detail=str(exc)
+                )
 
         # Ensure the output node has at least Geometry data
         if not output_node.geometry():


### PR DESCRIPTION
## Changelog Description
resolve #108 

These changes affect only publish plugins where we:
1. Update the error messages.
2. Errors related to user should raise `PublishError` with a clear message about what a user should do to fix the problem.
3. Errors that are not related user should raise `KnownPublishError` (This change might be reverted).
4. Avoid capturing any errors from lib functions e.g. `get_output_parameter`, `render_rop` and etc.


## Testing notes:
1. Everything should still work as before
2. Error messages related to the changes should be better.
