### PR TITLE
Add version up workfile menu entry when enabled in core settings

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -5,6 +5,7 @@ import errno
 import re
 import logging
 import json
+from functools import lru_cache
 from contextlib import contextmanager
 
 import six
@@ -1596,3 +1597,20 @@ def connect_file_parm_to_loader(file_parm: hou.Parm):
         f' {file_parm.node().path()} {file_parm.name()} \`{expression}\`'
     )
     show_node_parmeditor(load_node)
+
+
+@lru_cache(1)
+def is_version_up_workfile_menu_enabled() -> bool:
+    """Check if the 'Version Up Workfile' menu should be enabled.
+
+    It's cached because we don't care about updating the menu during the
+    current Houdini session and this allows us to avoid re-querying the
+    project settings each time.
+
+    """
+    project_settings = get_current_project_settings()
+    if project_settings["core"]["tools"]["ayon_menu"].get(
+        "version_up_current_workfile"
+    ):
+        return True
+    return False

--- a/client/ayon_houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_houdini/startup/MainMenuCommon.xml
@@ -16,6 +16,20 @@ return label
 
             <separatorItem/>
 
+            <scriptItem id="ayon_version_up_workfile">
+                <label>Version Up Workfile...</label>
+                <scriptCode><![CDATA[
+from ayon_core.pipeline.context_tools import version_up_current_workfile
+version_up_current_workfile()
+]]></scriptCode>
+                <expression>
+from ayon_houdini.api.lib import is_version_up_workfile_menu_enabled
+return is_version_up_workfile_menu_enabled()
+                </expression>
+            </scriptItem>
+
+            <separatorItem/>
+
             <scriptItem id="ayon_create">
                 <label>Create...</label>
                 <scriptCode><![CDATA[

--- a/client/ayon_houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_houdini/startup/MainMenuCommon.xml
@@ -17,7 +17,7 @@ return label
             <separatorItem/>
 
             <scriptItem id="ayon_version_up_workfile">
-                <label>Version Up Workfile...</label>
+                <label>Version Up Workfile</label>
                 <scriptCode><![CDATA[
 from ayon_core.pipeline.context_tools import version_up_current_workfile
 version_up_current_workfile()


### PR DESCRIPTION
## Changelog Description

Add version up workfile menu entry when enabled in core settings

## Additional review information

Similar to Blender PR https://github.com/ynput/ayon-blender/pull/84 but for Houdini
As requested on discord [here](https://discord.com/channels/517362899170230292/563751989075378201/1317086847238930434).

Note that it currently only saves if there are unsaved changes - this core PR https://github.com/ynput/ayon-core/pull/1054 would change it to always save.

Setting disabled:
![image](https://github.com/user-attachments/assets/bc125a42-7ed8-48fb-a48e-85e1c787d3a7)

Setting enabled:
![image](https://github.com/user-attachments/assets/0a996093-73f7-4ef0-b1a8-42213fdb380e)


## Testing notes:

1. Enable core setting: `ayon+settings://core/tools/ayon_menu/version_up_current_workfile`
2. When enabled the menu entry should show in Houdini after houdini startup.
3. Version up should work