### PR TITLE
change .bat to .cmd for Houdini 20 and higher

### DIFF
--- a/client/ayon_houdini/plugins/load/show_usdview.py
+++ b/client/ayon_houdini/plugins/load/show_usdview.py
@@ -22,7 +22,12 @@ class ShowInUsdview(plugin.HoudiniLoader):
         from pathlib import Path
 
         if platform.system() == "Windows":
-            executable = "usdview.bat"
+            houdiniVersion = os.environ["HOUDINI_VERSION"]
+            major = int(houdiniVersion.split(".")[0])
+            if major >= 20:
+                executable = "usdview.cmd"
+            else:
+                executable = "usdview.bat"
         else:
             executable = "usdview"
 


### PR DESCRIPTION
## Changelog Description
This PR changes the usdview executable file extension name from ".bat" to ".cmd" for Houdini 20 and higher.
This fixes the show in usdview button in the houdini loader for Houdini 20.

## Additional review information
Added Houdini version check that switches between the file extensions

## Testing notes:
1. Open Houdini 20
2. Use "view in usdview" button in Ayon-loader
