### PR TITLE
Chore: Remove 'six' usage

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -9,7 +9,6 @@ import clique
 from functools import lru_cache
 from contextlib import contextmanager
 
-import six
 import ayon_api
 
 import hou
@@ -451,7 +450,7 @@ def read(node):
     for parameter in node.spareParms():
         value = parameter.eval()
         # test if value is json encoded dict
-        if isinstance(value, six.string_types) and \
+        if isinstance(value, str) and \
                 value.startswith(JSON_PREFIX):
             try:
                 value = json.loads(value[len(JSON_PREFIX):])
@@ -561,7 +560,7 @@ def get_template_from_value(key, value):
                                    label=key,
                                    num_components=1,
                                    default_value=(value,))
-    elif isinstance(value, six.string_types):
+    elif isinstance(value, str):
         parm = hou.StringParmTemplate(name=key,
                                       label=key,
                                       num_components=1,

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Houdini specific Avalon/Pyblish plugin definitions."""
-import sys
-from abc import (
-    ABCMeta
-)
-import six
+"""Houdini specific AYON/Pyblish plugin definitions."""
 import hou
 
 import clique
@@ -101,7 +96,6 @@ class HoudiniCreatorBase(object):
         return instance_node
 
 
-@six.add_metaclass(ABCMeta)
 class HoudiniCreator(Creator, HoudiniCreatorBase):
     """Base class for most of the Houdini creator plugins."""
     selected_nodes = []
@@ -150,11 +144,8 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
 
             return instance
 
-        except hou.Error as er:
-            six.reraise(
-                CreatorError,
-                CreatorError("Creator error: {}".format(er)),
-                sys.exc_info()[2])
+        except hou.Error as exc:
+            raise CreatorError(f"Creator error: {exc}") from exc
 
     def lock_parameters(self, node, parameters):
         """Lock list of specified parameters on the node.


### PR DESCRIPTION
## Changelog Description
Remove `six` usage.

## Testing notes
1. Houdini errors are captured as `CreatorError` in create plugins.