### PR TITLE
Create destination folder if it doesn't already exist when saving

### DIFF
--- a/client/ayon_houdini/api/pipeline.py
+++ b/client/ayon_houdini/api/pipeline.py
@@ -108,6 +108,11 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
         # Force forwards slashes to avoid segfault
         if dst_path:
             dst_path = dst_path.replace("\\", "/")
+
+        # Create destination folder if it doesn't already exist.
+        if not os.path.exists(os.path.dirname(dst_path)):
+            os.makedirs(os.path.dirname(dst_path))
+
         hou.hipFile.save(file_name=dst_path,
                          save_to_recent_files=True)
         return dst_path

--- a/client/ayon_houdini/api/pipeline.py
+++ b/client/ayon_houdini/api/pipeline.py
@@ -110,7 +110,7 @@ class HoudiniHost(HostBase, IWorkfileHost, ILoadHost, IPublishHost):
             dst_path = dst_path.replace("\\", "/")
 
         # Create destination folder if it doesn't already exist.
-        if not os.path.exists(os.path.dirname(dst_path)):
+        if dst_path and not os.path.exists(os.path.dirname(dst_path)):
             os.makedirs(os.path.dirname(dst_path))
 
         hou.hipFile.save(file_name=dst_path,


### PR DESCRIPTION
## Changelog Description
resolve #218 

## Testing notes:
1. Launch Houdini
2. Run this in the source code editor
```
from ayon_core.pipeline import registered_host

host = registered_host()

file_path = r"{location to a folder or task that exist already on disk}\my_file.hip"
host.save_workfile(file_path)
```
