### PR TITLE
expand string before returning path in generic loaders

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -885,11 +885,11 @@ def expression_get_representation_path() -> str:
     use_entity_uri = bool(hou.evalParm("use_ayon_entity_uri"))
     hash_value = project_name, repre_id, use_entity_uri
     if hash_value in cache:
-        return cache[hash_value]
+        return hou.text.expandString(cache[hash_value])
 
     path = get_representation_path(project_name, repre_id, use_entity_uri)
     cache[hash_value] = path
-    return path
+    return hou.text.expandString(path)
 
 # endregion
 


### PR DESCRIPTION
## Changelog Description
resolve #222 

## Testing notes:
1. Load any sequence with generic loader
2. Reference file parm
3. the referenced parm has the evaluated path at the current frame.
