### PR TITLE
Load Asset/Shot LOP: revert parm name change except for the fixed `folder_name`

### DIFF
--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/Contents.dir/Contents.mime
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/Contents.dir/Contents.mime
@@ -195,7 +195,7 @@ Content-Type: text/plain
       defaultString = \"/character\"
       flags = 0
       start = 40
-      segment { length = 0 expr = chs(\"../primpath\") }
+      segment { length = 0 expr = chs(\"../primpath1\") }
     }
     channel reftype1 {
       lefttype = extend
@@ -203,14 +203,14 @@ Content-Type: text/plain
       defaultString = \"file\"
       flags = 0
       start = 40
-      segment { length = 0 expr = chs(\"../reftype\") }
+      segment { length = 0 expr = chs(\"../reftype1\") }
     }
     channel instanceable1 {
       lefttype = extend
       righttype = extend
       flags = 0
       start = 40
-      segment { length = 0 expr = ch(\"../instanceable\") }
+      segment { length = 0 expr = ch(\"../instanceable1\") }
     }
     channel filerefprim1 {
       lefttype = extend
@@ -218,7 +218,7 @@ Content-Type: text/plain
       defaultString = \"automaticPrim\"
       flags = 0
       start = 40
-      segment { length = 0 expr = chs(\"../filerefprim\") }
+      segment { length = 0 expr = chs(\"../filerefprim1\") }
     }
     channel filerefprimpath1 {
       lefttype = extend
@@ -226,14 +226,14 @@ Content-Type: text/plain
       defaultString = \"\"
       flags = 0
       start = 40
-      segment { length = 0 expr = chs(\"../filerefprimpath\") }
+      segment { length = 0 expr = chs(\"../filerefprimpath1\") }
     }
     channel timeoffset1 {
       lefttype = extend
       righttype = extend
       flags = 0
       start = 40
-      segment { length = 0 expr = ch(\"../timeoffset\") }
+      segment { length = 0 expr = ch(\"../timeoffset1\") }
     }
     channel timescale1 {
       lefttype = extend
@@ -241,7 +241,7 @@ Content-Type: text/plain
       default = 1
       flags = 0
       start = 40
-      segment { length = 0 value = 1 1 expr = ch(\"../timescale\") }
+      segment { length = 0 value = 1 1 expr = ch(\"../timescale1\") }
     }
     channel reload {
       lefttype = extend
@@ -465,14 +465,6 @@ Content-Type: text/plain
       start = 40
       segment { length = 0 expr = ch(\"../representation\") language = python }
     }
-    channel nodes_referencing_file {
-      lefttype = extend
-      righttype = extend
-      defaultString = \"\"
-      flags = 0
-      start = 40
-      segment { length = 0 expr = "\" \".join(parm.node().path() for parm in hou.parm('./file').parmsReferencingThis())" language = python }
-    }
     channel project_name {
       lefttype = extend
       righttype = extend
@@ -578,6 +570,14 @@ Content-Type: text/plain
       flags = 0
       start = 40
       segment { length = 0 expr = chs(\"../representation_name\") }
+    }
+    channel nodes_referencing_file {
+      lefttype = extend
+      righttype = extend
+      defaultString = \"\"
+      flags = 0
+      start = 40
+      segment { length = 0 expr = "\" \".join(parm.node().path() for parm in hou.parm('./file').parmsReferencingThis())" language = python }
     }
   }
 

--- a/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
+++ b/client/ayon_houdini/startup/otls/ayon_lop_import.hda/ayon_8_8Lop_1lop__import_8_81.0/DialogScript
@@ -21,7 +21,7 @@
         parmtag { "script_callback_language" "python" }
 
         parm {
-            name    "assetinfo"
+            name    "assetinfo_labelparm"
             label   "Heading"
             type    label
             default { "Choose Product" }
@@ -125,7 +125,7 @@
             parmtag { "script_callback_language" "python" }
         }
         parm {
-            name    "primpath"
+            name    "primpath1"
             label   "Primitive Root"
             type    string
             joinnext
@@ -149,7 +149,7 @@
                 "`chs(\"folder_name\")`"        "Folder Name\n    (Use for \"Asset Build\" workflow)"
                 "`chs(\"folder_path\")`/$OS"    "Folder Path with Node Name\n    (Use for \"Shot\" or \"Scene Assembly\" workflow)"
             }
-            parmtag { "script_callback" "parm = kwargs[\"node\"].parm(\"primpath\"); parm.revertToDefaults(); parm.set(kwargs[\"script_value\"])" }
+            parmtag { "script_callback" "parm = kwargs[\"node\"].parm(\"primpath1\"); parm.revertToDefaults(); parm.set(kwargs[\"script_value0\"])" }
             parmtag { "script_callback_language" "python" }
         }
         groupcollapsible {
@@ -157,7 +157,7 @@
             label   "Load Options"
 
             parm {
-                name    "reftype"
+                name    "reftype1"
                 label   "Reference Type"
                 type    string
                 default { "file" }
@@ -169,7 +169,7 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "instanceable"
+                name    "instanceable1"
                 label   "Make Instanceable"
                 type    toggle
                 default { "off" }
@@ -177,11 +177,11 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "filerefprim"
+                name    "filerefprim1"
                 label   "Reference Primitive"
                 type    string
                 default { "automaticPrim" }
-                hidewhen "{ reftype == prim } { reftype == inherit } { reftype == specialize }"
+                hidewhen "{ reftype1 == prim } { reftype1 == inherit } { reftype1 == specialize }"
                 menu {
                     "automaticPrim" "Reference Automatically Chosen Primitive"
                     "defaultPrim"   "Reference Default Primitive"
@@ -191,11 +191,11 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "filerefprimpath"
+                name    "filerefprimpath1"
                 label   "Reference Primitive Path"
                 type    string
                 default { "" }
-                disablewhen "{ filerefprim != \"\" reftype != prim reftype != inherit reftype != specialize }"
+                disablewhen "{ filerefprim1 != \"\" reftype1 != prim reftype1 != inherit reftype1 != specialize }"
                 parmtag { "autoscope" "0000000000000000" }
                 parmtag { "script_action" "import loputils\nnode = kwargs['node']\nparm = kwargs['parmtuple'][0]\nreftype = node.evalParm(parm.name().replace(\n    'filerefprimpath', 'reftype'))\nif reftype in ('prim', 'inherit', 'specialize'):\n    prims = loputils.selectPrimsInParm(kwargs, True)\nelse:\n    parm = node.parm(parm.name().replace(\n       'filerefprimpath', 'filepath'))\n    prims = loputils.selectPrimsInParmFromFile(kwargs, False,\n        parm.evalAsString().strip('\\'\"'))" }
                 parmtag { "script_action_help" "Select a primitive from a primitive picker dialog." }
@@ -204,7 +204,7 @@
                 parmtag { "sidefx::usdpathtype" "prim" }
             }
             parm {
-                name    "timeoffset"
+                name    "timeoffset1"
                 label   "Time Offset (in Frames)"
                 type    float
                 default { "0" }
@@ -213,7 +213,7 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "timescale"
+                name    "timescale1"
                 label   "Time Scale"
                 type    float
                 default { "1" }

--- a/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/Contents.dir/Contents.mime
+++ b/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/Contents.dir/Contents.mime
@@ -196,14 +196,14 @@ Content-Type: text/plain
       righttype = extend
       flags = 0
       start = 40
-      segment { length = 0 expr = ch(\"../mute\") }
+      segment { length = 0 expr = ch(\"../mute1\") }
     }
     channel timeoffset1 {
       lefttype = extend
       righttype = extend
       flags = 0
       start = 40
-      segment { length = 0 expr = ch(\"../timeoffset\") }
+      segment { length = 0 expr = ch(\"../timeoffset1\") }
     }
     channel timescale1 {
       lefttype = extend
@@ -211,7 +211,7 @@ Content-Type: text/plain
       default = 1
       flags = 0
       start = 40
-      segment { length = 0 value = 1 1 expr = ch(\"../timescale\") }
+      segment { length = 0 value = 1 1 expr = ch(\"../timescale1\") }
     }
   }
 
@@ -419,14 +419,6 @@ Content-Type: text/plain
       start = 40
       segment { length = 0 expr = ch(\"../representation\") language = python }
     }
-    channel nodes_referencing_file {
-      lefttype = extend
-      righttype = extend
-      defaultString = \"\"
-      flags = 0
-      start = 40
-      segment { length = 0 expr = "\" \".join(parm.node().path() for parm in hou.parm('./file').parmsReferencingThis())" language = python }
-    }
     channel project_name {
       lefttype = extend
       righttype = extend
@@ -502,6 +494,14 @@ Content-Type: text/plain
       flags = 0
       start = 40
       segment { length = 0 expr = ch(\"../show_pipeline_parms\") }
+    }
+    channel nodes_referencing_file {
+      lefttype = extend
+      righttype = extend
+      defaultString = \"\"
+      flags = 0
+      start = 40
+      segment { length = 0 expr = "\" \".join(parm.node().path() for parm in hou.parm('./file').parmsReferencingThis())" language = python }
     }
   }
 

--- a/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/DialogScript
+++ b/client/ayon_houdini/startup/otls/ayon_lop_load_shot.hda/ayon_8_8Lop_1load__shot_8_81.0/DialogScript
@@ -21,7 +21,7 @@
         parmtag { "script_callback_language" "python" }
 
         parm {
-            name    "assetinfo"
+            name    "assetinfo_labelparm"
             label   "Heading"
             type    label
             default { "Choose Product" }
@@ -129,7 +129,7 @@
             label   "Load Options"
 
             parm {
-                name    "mute"
+                name    "mute1"
                 label   "Mute Layer"
                 type    toggle
                 default { "off" }
@@ -137,7 +137,7 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "timeoffset"
+                name    "timeoffset1"
                 label   "Time Offset (in Frames)"
                 type    float
                 default { "0" }
@@ -146,7 +146,7 @@
                 parmtag { "script_callback_language" "python" }
             }
             parm {
-                name    "timescale"
+                name    "timescale1"
                 label   "Time Scale"
                 type    float
                 default { "1" }


### PR DESCRIPTION
## Changelog Description

Revert parm names back to prior #226 to align with earlier releases, only keep the fixed `folder_name` parm on LOP import change from that PR.

## Additional review information

**Critical note** This would be useful for a hotfix release - so that scenes remain backwards compatible to loaded content from ayon-houdini 0.4.2 and below. Only 0.4.3 release would then be the outlier with the invalid parm names.

Without this any parm overrides, e.g. to Primitive Root `primpath1` on the LOP import (load asset LOP) would be lost in the existing scenes.

Fixes what's described here: https://github.com/ynput/ayon-houdini/pull/226#issuecomment-2682993899

## Testing notes:

1. Load Asset LOP and Load Shot LOP should still work as intended (including all their attributes, like Primitive Root, time offset, etc.)
2. Load Asset LOP and Load Shot LOP overrides (from ayon-houdini 0.4.2 and before) stored on these parms should be maintained.
