### PR TITLE
Thumbnail should run before heavy processes so houdini does not crash

### DIFF
--- a/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
+++ b/client/ayon_houdini/plugins/publish/extract_active_view_thumbnail.py
@@ -15,7 +15,7 @@ class ExtractActiveViewThumbnail(plugin.HoudiniExtractorPlugin,
     publishing as a fallback.
 
     """
-    order = pyblish.api.ExtractorOrder + 0.49
+    order = pyblish.api.ExtractorOrder + 0.25
     label = "Extract Active View Thumbnail"
     families = ["workfile"]
 


### PR DESCRIPTION
## Problem
We experienced segfault houdini crashes on thumbnail creation, when publishing products. This happens because heavy extractors (in our case the HDA extractor) still block the main thread at the moment when the process moves to the next extractor, which crashes the flipbook tool.

## Changes
We change the extractor order to 0.25 so the thumbnail executes before the product extractors, which mitigates the problem

