### PR TITLE
Add "rig" product type to publish APEX rigs to BGEO

### DIFF
--- a/client/ayon_houdini/plugins/create/create_rig.py
+++ b/client/ayon_houdini/plugins/create/create_rig.py
@@ -1,0 +1,107 @@
+import inspect
+
+from ayon_houdini.api import plugin
+from ayon_core.lib import EnumDef
+from ayon_core.pipeline import CreatorError
+
+import hou
+
+
+class CreateRig(plugin.HoudiniCreator):
+    """APEX Rig (bgeo) creator."""
+    identifier = "io.ayon.creators.houdini.bgeo.rig"
+    label = "Rig"
+    product_type = "rig"
+    icon = "wheelchair"
+
+    description = "APEX rig exported as BGEO file"
+
+    def get_detail_description(self):
+        return inspect.cleandoc(
+            """Write a BGEO output file as `rig` product type. This can be
+            used to publish APEX rigs which are in essence just SOP-level
+            data representing a rig structure."""
+        )
+
+    def get_publish_families(self):
+        return ["rig", "bgeo"]
+
+    def create(self, product_name, instance_data, pre_create_data):
+        instance = super().create(product_name, instance_data, pre_create_data)
+
+        instance_node = hou.node(instance.get("instance_node"))
+
+        file_path = "{}{}".format(
+            hou.text.expandString("$HIP/pyblish/"),
+            "{}.$F4.{}".format(
+                product_name,
+                pre_create_data.get("bgeo_type") or "bgeo.sc")
+        )
+        parms = {
+            "sopoutput": file_path
+        }
+
+        if self.selected_nodes:
+            # if selection is on SOP level, use it
+            if isinstance(self.selected_nodes[0], hou.SopNode):
+                parms["soppath"] = self.selected_nodes[0].path()
+            else:
+                # try to find output node with the lowest index
+                outputs = [
+                    child for child in self.selected_nodes[0].children()
+                    if child.type().name() == "output"
+                ]
+                if not outputs:
+                    instance_node.setParms(parms)
+                    raise CreatorError((
+                        "Missing output node in SOP level for the selection. "
+                        "Please select correct SOP path in created instance."
+                    ))
+                outputs.sort(key=lambda output: output.evalParm("outputidx"))
+                parms["soppath"] = outputs[0].path()
+
+        instance_node.setParms(parms)
+
+    def get_pre_create_attr_defs(self):
+        attrs = super().get_pre_create_attr_defs()
+        bgeo_enum = [
+            {
+                "value": "bgeo",
+                "label": "uncompressed bgeo (.bgeo)"
+            },
+            {
+                "value": "bgeosc",
+                "label": "BLOSC compressed bgeo (.bgeosc)"
+            },
+            {
+                "value": "bgeo.sc",
+                "label": "BLOSC compressed bgeo (.bgeo.sc)"
+            },
+            {
+                "value": "bgeo.gz",
+                "label": "GZ compressed bgeo (.bgeo.gz)"
+            },
+            {
+                "value": "bgeo.lzma",
+                "label": "LZMA compressed bgeo (.bgeo.lzma)"
+            },
+            {
+                "value": "bgeo.bz2",
+                "label": "BZip2 compressed bgeo (.bgeo.bz2)"
+            }
+        ]
+
+        return attrs + [
+            EnumDef(
+                "bgeo_type",
+                bgeo_enum,
+                default="bgeo.sc",
+                label="BGEO Options"
+            ),
+        ] + self.get_instance_attr_defs()
+
+    def get_network_categories(self):
+        return [
+            hou.ropNodeTypeCategory(),
+            hou.sopNodeTypeCategory()
+        ]

--- a/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -16,7 +16,7 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
     label = "Collect Frames"
     families = ["camera", "vdbcache", "imagesequence", "ass",
                 "redshiftproxy", "review", "pointcache", "fbx",
-                "model"]
+                "model", "bgeo"]
 
     def process(self, instance):
 


### PR DESCRIPTION
## Changelog Description

Add "rig" product type to publish APEX rigs to BGEO

## Additional review information

Adds a "Rig" creator:

![image](https://github.com/user-attachments/assets/571e21cd-b97b-4ac9-8d4e-452a372d2bc2)

![image](https://github.com/user-attachments/assets/ad046af2-a896-4c24-9a03-679ff0857861)


Fix https://github.com/ynput/ayon-houdini/issues/237

This required a workaround for validating the handles because the rigs aren't intended to be frame-range based. I'm not sure I _like_ the fix, but couldn't quickly think of anything nicer than this.

## Testing notes:

1. Create rig to publish any SOP level data, e.g. any APEX rig.
2. Note: There's no validation currently whether the data published is ACTUALLY an apex rig.
3. Publishes fine to bgeo.
4. The published data works fine loaded back in for animating with the APEX rig.