### PR TITLE
Create Redshift ROP: Expose `multi_layered_mode` to settings

### DIFF
--- a/client/ayon_houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_rop.py
@@ -15,7 +15,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     product_type = "redshift_rop"
     icon = "magic"
     ext = "exr"
-    multi_layered_mode = "No Multi-Layered EXR File"
+    multi_layered_mode = "0"  # No Multi-Layered EXR File
 
     # Default render target
     render_target = "farm_split"
@@ -57,12 +57,11 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
 
         # Set the linked rop to the Redshift ROP
         ipr_rop.parm("linked_rop").set(instance_node.path())
-        ext = pre_create_data.get("image_format")
-        multi_layered_mode = pre_create_data.get("multi_layered_mode")
+        ext: int = pre_create_data.get("image_format", 0)
+        multi_layered_mode: str = pre_create_data.get(
+            "multi_layered_mode", "1")
 
         ext_format_index = {"exr": 0, "tif": 1, "jpg": 2, "png": 3}
-        multilayer_mode_index = {"No Multi-Layered EXR File": "1",
-                                 "Full Multi-Layered EXR File": "2" }
 
         filepath = "{renders_dir}{product_name}/{product_name}.{fmt}".format(
                 renders_dir=hou.text.expandString("$HIP/pyblish/renders/"),
@@ -70,11 +69,14 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
                 fmt="$AOV.$F4.{ext}".format(ext=ext)
             )
 
-        if multilayer_mode_index[multi_layered_mode] == "1":
+        if multi_layered_mode == "1":
             multipart = False
-
-        elif multilayer_mode_index[multi_layered_mode] == "2":
+        elif multi_layered_mode == "2":
             multipart = True
+        else:
+            raise ValueError(
+                f"Unknown value for 'multi_layered_mode': {multi_layered_mode}"
+            )
 
         parms = {
             # Render frame range
@@ -85,9 +87,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
             "RS_outputFileFormat": ext_format_index[ext],
         }
         if ext == "exr":
-            parms["RS_outputMultilayerMode"] = (
-                multilayer_mode_index[multi_layered_mode]
-            )
+            parms["RS_outputMultilayerMode"] = multi_layered_mode
             parms["RS_aovMultipart"] = multipart
 
         if self.selected_nodes:
@@ -153,8 +153,8 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         ]
 
         multi_layered_mode = [
-            "No Multi-Layered EXR File",
-            "Full Multi-Layered EXR File"
+            {"value": "0", "label": "No Multi-Layered EXR File"},
+            {"value": "1", "label": "Full Multi-Layered EXR File"},
         ]
 
         attrs = super(CreateRedshiftROP, self).get_pre_create_attr_defs()

--- a/client/ayon_houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_rop.py
@@ -15,7 +15,7 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
     product_type = "redshift_rop"
     icon = "magic"
     ext = "exr"
-    multi_layered_mode = "0"  # No Multi-Layered EXR File
+    multi_layered_mode = "1"  # No Multi-Layered EXR File
 
     # Default render target
     render_target = "farm_split"
@@ -153,8 +153,8 @@ class CreateRedshiftROP(plugin.HoudiniCreator):
         ]
 
         multi_layered_mode = [
-            {"value": "0", "label": "No Multi-Layered EXR File"},
-            {"value": "1", "label": "Full Multi-Layered EXR File"},
+            {"value": "1", "label": "No Multi-Layered EXR File"},
+            {"value": "2", "label": "Full Multi-Layered EXR File"},
         ]
 
         attrs = super(CreateRedshiftROP, self).get_pre_create_attr_defs()

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -50,14 +50,14 @@ class CreateStaticMeshModel(BaseSettingsModel):
 
 def redshift_multi_layered_mode_enum():
     return [
-        {"label": "No Multi-Layered EXR File", "value": "0"},
-        {"label": "Full Multi-Layered EXR File", "value": "1"}
+        {"label": "No Multi-Layered EXR File", "value": "1"},
+        {"label": "Full Multi-Layered EXR File", "value": "2"}
     ]
 
 
 class CreateRedshiftROPModel(CreatorModel):
     multi_layered_mode: str = SettingsField(
-        "0",
+        "1",
         title="Multi Layered Mode",
         description=(
             "Default Multi Layered Mode when creating a new Redshift ROP"
@@ -190,7 +190,7 @@ DEFAULT_HOUDINI_CREATE_SETTINGS = {
     "CreateRedshiftROP": {
         "enabled": True,
         "default_variants": ["Main"],
-        "multi_layered_mode": "0"
+        "multi_layered_mode": "1"
     },
     "CreateReview": {
         "enabled": True,

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -48,6 +48,24 @@ class CreateStaticMeshModel(BaseSettingsModel):
     )
 
 
+def redshift_multi_layered_mode_enum():
+    return [
+        {"label": "No Multi-Layered EXR File", "value": "0"},
+        {"label": "Full Multi-Layered EXR File", "value": "1"}
+    ]
+
+
+class CreateRedshiftROPModel(CreatorModel):
+    multi_layered_mode: str = SettingsField(
+        "0",
+        title="Multi Layered Mode",
+        description=(
+            "Default Multi Layered Mode when creating a new Redshift ROP"
+        ),
+        enum_resolver=redshift_multi_layered_mode_enum,
+    )
+
+
 class CreateUSDRenderModel(CreatorModel):
     default_renderer: str = SettingsField(
         "Karma CPU",
@@ -95,8 +113,8 @@ class CreatePluginsModel(BaseSettingsModel):
     CreateRedshiftProxy: CreatorModel = SettingsField(
         default_factory=CreatorModel,
         title="Create Redshift Proxy")
-    CreateRedshiftROP: CreatorModel = SettingsField(
-        default_factory=CreatorModel,
+    CreateRedshiftROP: CreateRedshiftROPModel = SettingsField(
+        default_factory=CreateRedshiftROPModel,
         title="Create Redshift ROP")
     CreateReview: CreateReviewModel = SettingsField(
         default_factory=CreateReviewModel,
@@ -171,7 +189,8 @@ DEFAULT_HOUDINI_CREATE_SETTINGS = {
     },
     "CreateRedshiftROP": {
         "enabled": True,
-        "default_variants": ["Main"]
+        "default_variants": ["Main"],
+        "multi_layered_mode": "0"
     },
     "CreateReview": {
         "enabled": True,


### PR DESCRIPTION
## Changelog Description

Allow to set default value for multilayer mode pre create attributes

## Additional review information

Adds `ayon+settings://houdini/create/CreateRedshiftROP/multi_layered_mode`

![image](https://github.com/user-attachments/assets/9e424fad-078a-434d-9a85-68b64005f2e9)

Fix #239

## Testing notes:

1. Upload addon
2. Test setting with creator in publisher UI, it should adhere to the setting on create.
