### PR TITLE
Load Image: Fix loading render if there's no colorspace data

### DIFF
--- a/client/ayon_houdini/plugins/load/load_image.py
+++ b/client/ayon_houdini/plugins/load/load_image.py
@@ -184,5 +184,7 @@ class ImageLoader(plugin.HoudiniLoader):
                 "ocio_space": colorspace
             }
 
+        return {}
+
     def switch(self, container, representation):
         self.update(container, representation)


### PR DESCRIPTION
## Changelog Description
resolve #241
`get_colorspace_parms` should always return a dict. 

## Testing notes:
1. loading render without colorspace shouldn't error.
