### PR TITLE
Manage: Add "Show parameters" action

### DIFF
--- a/client/ayon_houdini/plugins/inventory/show_parameters.py
+++ b/client/ayon_houdini/plugins/inventory/show_parameters.py
@@ -5,7 +5,7 @@ import hou
 
 
 class ShowParametersAction(InventoryAction):
-
+    """Show node parameters in a pop-up parameter window."""
     label = "Show parameters"
     icon = "pencil-square-o"
     color = "#888888"

--- a/client/ayon_houdini/plugins/inventory/show_parameters.py
+++ b/client/ayon_houdini/plugins/inventory/show_parameters.py
@@ -1,0 +1,29 @@
+from ayon_core.pipeline import InventoryAction
+from ayon_houdini.api.lib import show_node_parmeditor
+
+import hou
+
+
+class ShowParametersAction(InventoryAction):
+
+    label = "Show parameters"
+    icon = "pencil-square-o"
+    color = "#888888"
+    order = 100
+
+    @staticmethod
+    def is_compatible(container) -> bool:
+        object_name: str = container.get("objectName")
+        if not object_name:
+            return False
+
+        node = hou.node(object_name)
+        if not node:
+            return False
+
+        return True
+
+    def process(self, containers):
+        for container in containers:
+            node = hou.node(container["objectName"])
+            show_node_parmeditor(node)


### PR DESCRIPTION
## Changelog Description

Add "Show Parameters" action which allows to quickly show the node in a pop-up parameter window for a loaded product. Making it easy to quickly tweak a setting on a loaded object, especially useful for e.g. custom loaders using e.g. Generic Loaders internally.

## Additional review information

![image](https://github.com/user-attachments/assets/c4c15154-dfef-4e68-a9d0-43e6d4a0c4c0)

Shows e.g.

![image](https://github.com/user-attachments/assets/5dd3d62a-193c-4c0f-9955-9238ded8a75f)

## Testing notes:
1. Show Parameters action should work
2. Action should be useful
