### PR TITLE
Validate USD Look Disallowed Types: make customizable in settings

### DIFF
--- a/client/ayon_houdini/plugins/publish/validate_usd_look_disallowed_types.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_look_disallowed_types.py
@@ -6,6 +6,7 @@ from functools import partial
 from pxr import Sdf
 import pyblish.api
 
+from ayon_core.pipeline import OptionalPyblishPluginMixin
 from ayon_core.pipeline.publish import PublishValidationError
 from ayon_houdini.api.action import SelectROPAction
 from ayon_houdini.api.usd import get_schema_type_names
@@ -17,7 +18,8 @@ def get_applied_items(list_proxy) -> List[Union[Sdf.Reference, Sdf.Payload]]:
     return list_proxy.ApplyEditsToList([])
 
 
-class ValidateUsdLookDisallowedTypes(plugin.HoudiniInstancePlugin):
+class ValidateUsdLookDisallowedTypes(plugin.HoudiniInstancePlugin,
+                                     OptionalPyblishPluginMixin):
     """Validate no meshes are defined in the look.
 
     Usually, a published look should not contain generated meshes in the output
@@ -42,6 +44,8 @@ class ValidateUsdLookDisallowedTypes(plugin.HoudiniInstancePlugin):
     ]
 
     def process(self, instance):
+        if not self.is_active(instance.data):
+            return
 
         # Get Sdf.Layers from "Collect ROP Sdf Layers and USD Stage" plug-in
         layers = instance.data.get("layers")

--- a/client/ayon_houdini/plugins/publish/validate_usd_look_disallowed_types.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_look_disallowed_types.py
@@ -17,7 +17,7 @@ def get_applied_items(list_proxy) -> List[Union[Sdf.Reference, Sdf.Payload]]:
     return list_proxy.ApplyEditsToList([])
 
 
-class ValidateUsdLookContents(plugin.HoudiniInstancePlugin):
+class ValidateUsdLookDisallowedTypes(plugin.HoudiniInstancePlugin):
     """Validate no meshes are defined in the look.
 
     Usually, a published look should not contain generated meshes in the output
@@ -31,7 +31,7 @@ class ValidateUsdLookContents(plugin.HoudiniInstancePlugin):
     order = pyblish.api.ValidatorOrder
     families = ["look"]
     hosts = ["houdini"]
-    label = "Validate Look No Meshes/Lights"
+    label = "Validate Look No Disallowed Types"
     actions = [SelectROPAction]
 
     disallowed_types = [

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -107,6 +107,21 @@ class BasicEnabledStatesModel(BaseSettingsModel):
     active: bool = SettingsField(title="Active")
 
 
+class ValidateUsdLookDisallowedTypesModel(BasicEnabledStatesModel):
+    disallowed_types: list[str] = SettingsField(
+        default_factory=list,
+        title="Disallowed Types",
+        description=(
+            "Disallowed types for look product. "
+            "This should be USD schema types like:\n"
+            "- `UsdGeomBoundable` for Meshes/Lights/Procedurals\n"
+            "- `UsdRenderSettingsBase` for Render Settings\n"
+            "- `UsdRenderVar` for Render Var\n"
+            "- `UsdGeomCamera` for Cameras"
+        )
+    )
+
+
 class ExtractUsdModel(BaseSettingsModel):
     use_ayon_entity_uri: bool = SettingsField(
         False,
@@ -158,6 +173,12 @@ class PublishPluginsModel(BaseSettingsModel):
     ValidateUsdLookAssignments: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Validate USD Look Assignments")
+    ValidateUsdLookDisallowedTypes: ValidateUsdLookDisallowedTypesModel = (
+        SettingsField(
+            default_factory=ValidateUsdLookDisallowedTypesModel,
+            title="Validate USD Look Disallowed Types"
+        )
+    )
     ValidateUSDRenderProductPaths: BasicEnabledStatesModel = SettingsField(
         default_factory=BasicEnabledStatesModel,
         title="Validate USD Render Product Paths")
@@ -246,6 +267,17 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
         "enabled": True,
         "optional": True,
         "active": True
+    },
+    "ValidateUsdLookDisallowedTypes": {
+        "enabled": True,
+        "optional": True,
+        "active": True,
+        "disallowed_types": [
+            "UsdGeomBoundable",
+            "UsdRenderSettingsBase",
+            "UsdRenderVar",
+            "UsdGeomCamera"
+        ]
     },
     "ValidateUSDRenderProductPaths": {
         "enabled": False,

--- a/server/settings/publish.py
+++ b/server/settings/publish.py
@@ -270,7 +270,7 @@ DEFAULT_HOUDINI_PUBLISH_SETTINGS = {
     },
     "ValidateUsdLookDisallowedTypes": {
         "enabled": True,
-        "optional": True,
+        "optional": False,
         "active": True,
         "disallowed_types": [
             "UsdGeomBoundable",


### PR DESCRIPTION
## Changelog Description

Make Validate USD Look Disallowed Types customizable (make optional, allow types to be altered)

## Additional review information

You can now customize the Validate USD Look Contents to define whether the validation is optional, enabled/disabled or even specify the USD type names in settings to decide which things to disallow.

## Testing notes:

1. Tweak the settings.
2. The validator should adhere to the changes.
