### PR TITLE
Create Review: Fix setting `imageFormat` extension on create

### DIFF
--- a/client/ayon_houdini/plugins/create/create_review.py
+++ b/client/ayon_houdini/plugins/create/create_review.py
@@ -58,7 +58,7 @@ class CreateReview(plugin.HoudiniCreator):
             root=hou.text.expandString("$HIP/pyblish"),
             # keep dynamic link to product name
             product_name="`chs(\"AYON_productName\")`",
-            ext=pre_create_data.get("image_format") or "png"
+            ext=pre_create_data.get("imageFormat") or "png"
         )
 
         parms = {


### PR DESCRIPTION
## Changelog Description

Create Review: Fix setting `imageFormat` extension on create

## Additional review information

Previously the output path would always have been set to `png`. Now it should adhere to what user selected on create.

## Testing notes:

1. Creating and publishing should work as inteded.
