### PR TITLE
Create Review: Fix `<USE_DISPLAY_NAME>` value in color correction create and review

### DIFF
--- a/client/ayon_houdini/api/colorspace.py
+++ b/client/ayon_houdini/api/colorspace.py
@@ -52,14 +52,17 @@ def get_scene_linear_colorspace():
     return colorspaces["roles"].get("scene_linear", {}).get("colorspace")
 
 
-def get_default_display_view_colorspace():
+def get_default_display_view_colorspace() -> str:
     """Returns the colorspace attribute of the default (display, view) pair.
 
     It's used for 'ociocolorspace' parm in OpenGL Node."""
 
     prefs = get_color_management_preferences()
-    return get_display_view_colorspace_name(
+    colorspace = get_display_view_colorspace_name(
         config_path=prefs["config"],
         display=prefs["display"],
         view=prefs["view"]
     )
+    if colorspace == "<USE_DISPLAY_NAME>":
+        colorspace = prefs["display"]
+    return colorspace


### PR DESCRIPTION
## Changelog Description

Create Review: Fix `<USE_DISPLAY_NAME>` value in color correction create and review

## Additional review information

Fix https://github.com/ynput/ayon-houdini/issues/179

## Testing notes:

1. Create review instance with OCIO management enabled should set correct Color Correction OCIO Colorspace value/
2. Validation should also run correctly.