### PR TITLE
use `variant` instance data not `product name`

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -223,6 +223,6 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
             task_entity=instance.context.data["taskEntity"],
             host_name=instance.context.data["hostName"],
             product_type=product_type,
-            variant=instance.data["productName"],
+            variant=instance.data["variant"],
             dynamic_data=dynamic_data
         )


### PR DESCRIPTION
## Changelog Description
resolve #256 

![image](https://github.com/user-attachments/assets/6275c9a9-7caa-4084-9626-77fa108cc7e4)
for the above image, Template: `{product[type]}{Variant}<_{Aov}>`
for run time instances: 
- type is `render`
- variant is `Main`

## Testing notes:
1. Create a render instance
2. Set render target to local
3. Check instances names
