### PR TITLE
Modify ayon's stylesheet to express font-size in pixels rather than p…

### DIFF
--- a/client/ayon_houdini/api/__init__.py
+++ b/client/ayon_houdini/api/__init__.py
@@ -12,6 +12,8 @@ from .lib import (
     maintained_selection
 )
 
+import hou
+hou.logging.createSource("AYON")
 
 __all__ = [
     "HoudiniHost",

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -54,23 +54,20 @@ def load_adapted_stylesheet(widget: QtWidgets.QWidget) -> str:
     try:
         return load_adapted_stylesheet.cache[dpr]
     except AttributeError:
-        hou.logging.log(
-            hou.logging.LogEntry(
-                message=f"load_adapted_stylesheet: AttributeError: {dpr}",
-                source="AYON",
-            )
-        )
         setattr(load_adapted_stylesheet, "cache", {})
     except KeyError:
-        hou.logging.log(
-            hou.logging.LogEntry(
-                message=f"load_adapted_stylesheet: KeyError: {dpr}",
-                source="AYON",
-            )
+        pass
+
+    # if we arrive here, a new cache entry must be created.
+    hou.logging.log(
+        hou.logging.LogEntry(
+            message=f"load_adapted_stylesheet: new cache entry: {dpr}",
+            source="AYON",
         )
+    )
 
     def _convert(match):
-        size = int((int(match.group(2)) + 1) * hou.ui.globalScaleFactor())
+        size = int((int(match.group(2)) * 1.1) * hou.ui.globalScaleFactor())
         size = int(size / dpr)
         return f"{match.group(1)}{size}px;"
 

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -43,6 +43,10 @@ def load_adapted_stylesheet() -> str:
     sizes from points (pt) to pixels (px), and caches the result for future
     use.
 
+    Houdini seems to handle pixels more gracefully than points on Windows, but
+    using pixels across the board creates more problems, so we keep this fix
+    local until a better solution emerges.
+
     Returns:
         str: The adapted stylesheet as a string.
     """

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -40,7 +40,7 @@ def load_adapted_stylesheet() -> str:
         return load_adapted_stylesheet.cache
     except AttributeError:
         css = load_stylesheet()
-        css = re.sub("(font-size:\s+\d+)pt;", "\\1px;", css)
+        css = re.sub(r"(font-size:\s+\d+)pt;", "\\1px;", css)
         setattr(load_adapted_stylesheet, "cache", css)
     return load_adapted_stylesheet.cache
 

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -35,6 +35,15 @@ from ayon_houdini.api import lib
 from .usd import get_ayon_entity_uri_from_representation_context
 
 
+def load_adapted_stylesheet() -> str:
+    try:
+        return load_adapted_stylesheet.cache
+    except AttributeError:
+        css = load_stylesheet()
+        css = re.sub("(font-size:\s+\d+)pt;", "\\1px;", css)
+        setattr(load_adapted_stylesheet, "cache", css)
+    return load_adapted_stylesheet.cache
+
 def get_session_cache() -> dict:
     """Get a persistent `hou.session.ayon_cache` dict"""
     cache = getattr(hou.session, "ayon_cache", None)
@@ -509,7 +518,7 @@ class SelectFolderPathDialog(QtWidgets.QDialog):
     def __init__(self, parent=None):
         super(SelectFolderPathDialog, self).__init__(parent)
         self.setWindowTitle("Set project and folder path")
-        self.setStyleSheet(load_stylesheet())
+        self.setStyleSheet(load_adapted_stylesheet())
 
         project_widget = QtWidgets.QComboBox()
         project_widget.addItems(self.get_projects())
@@ -593,7 +602,7 @@ def select_folder_path(node):
             dialog.folder_widget.set_selected_folder_path(folder_path)
         QtCore.QTimer.singleShot(100, _select_folder_path)
 
-    dialog.setStyleSheet(load_stylesheet())
+    dialog.setStyleSheet(load_adapted_stylesheet())
 
     # Make it appear like a pop-up near cursor
     dialog.resize(300, 600)
@@ -634,7 +643,7 @@ class SelectProductDialog(QtWidgets.QDialog):
     def __init__(self, project_name, folder_id, parent=None):
         super(SelectProductDialog, self).__init__(parent)
         self.setWindowTitle("Select a Product")
-        self.setStyleSheet(load_stylesheet())
+        self.setStyleSheet(load_adapted_stylesheet())
 
         self.project_name = project_name
         self.folder_id = folder_id

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1472,7 +1472,6 @@ def prompt_reset_context():
     from ayon_core.tools.attribute_defs.dialog import (
         AttributeDefinitionsDialog
     )
-    from ayon_core.style import load_stylesheet
     from . hda_utils import load_adapted_stylesheet
     from ayon_core.lib import BoolDef, UILabelDef
 

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1473,6 +1473,7 @@ def prompt_reset_context():
         AttributeDefinitionsDialog
     )
     from ayon_core.style import load_stylesheet
+    from . hda_utils import load_adapted_stylesheet
     from ayon_core.lib import BoolDef, UILabelDef
 
     definitions = [
@@ -1506,7 +1507,7 @@ def prompt_reset_context():
 
     dialog = AttributeDefinitionsDialog(definitions)
     dialog.setWindowTitle("Saving to different context.")
-    dialog.setStyleSheet(load_stylesheet())
+    dialog.setStyleSheet(load_adapted_stylesheet())
     if not dialog.exec_():
         return None
 

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1472,7 +1472,7 @@ def prompt_reset_context():
     from ayon_core.tools.attribute_defs.dialog import (
         AttributeDefinitionsDialog
     )
-    from . hda_utils import load_adapted_stylesheet
+    from .hda_utils import load_adapted_stylesheet
     from ayon_core.lib import BoolDef, UILabelDef
 
     definitions = [

--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1506,7 +1506,7 @@ def prompt_reset_context():
 
     dialog = AttributeDefinitionsDialog(definitions)
     dialog.setWindowTitle("Saving to different context.")
-    dialog.setStyleSheet(load_adapted_stylesheet())
+    dialog.setStyleSheet(load_adapted_stylesheet(dialog))
     if not dialog.exec_():
         return None
 


### PR DESCRIPTION
Modify ayon's stylesheet to express font-size in pixels rather than points.

## Changelog Description
Houdini seems to prefer font size in pixels rather than points. Sadly, this is breaking other integrations, so we are opting for a local fix.

## Additional review information
The main culprit is the SelectFolderPathDialog accessed from the generic loader, but other UIs should be tested too.
This seems to be mostly a Windows bug, but all plaforms should be tested.

## Testing notes:
1. Launch houdini
2. Create an AYON Generic Loader
3. Click the picker icon on the right side of the `product` field to see if everything looks ok.
4. Open all other UIs you can think of.