### PR TITLE
USD Asset Creators: Add `Asset` to the USD asset creator labels

### DIFF
--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -85,10 +85,10 @@ class CreateUSD(plugin.HoudiniCreator):
 
 class CreateUSDModel(CreateUSD):
     identifier = "io.ayon.creators.houdini.model.usd"
-    label = "USD Model"
+    label = "USD Asset Model"
     product_type = "model"
     enabled = True
-    description = "Create USD model"
+    description = "Create USD Asset model"
 
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
@@ -107,10 +107,10 @@ class CreateUSDModel(CreateUSD):
 
 class CreateUSDAssembly(CreateUSD):
     identifier = "io.ayon.creators.houdini.assembly.usd"
-    label = "USD Assembly"
+    label = "USD Asset Assembly"
     product_type = "assembly"
     enabled = True
-    description = "Create USD assembly"
+    description = "Create USD Asset assembly"
 
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
@@ -129,11 +129,11 @@ class CreateUSDAssembly(CreateUSD):
 
 class CreateUSDGroom(CreateUSD):
     identifier = "io.ayon.creators.houdini.groom.usd"
-    label = "USD Groom"
+    label = "USD Asset Groom"
     product_type = "groom"
     icon = "scissors"
     enabled = True
-    description = "Create USD groom of fur and or hairs"
+    description = "Create USD Asset groom of fur and or hairs"
 
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
@@ -155,11 +155,11 @@ class CreateUSDLook(CreateUSD):
     """Universal Scene Description Look"""
 
     identifier = "io.openpype.creators.houdini.usd.look"
-    label = "USD Look"
+    label = "USD Asset Look"
     product_type = "look"
     icon = "paint-brush"
     enabled = True
-    description = "Create USD Look with localized textures"
+    description = "Create USD Asset Look with localized textures"
 
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being


### PR DESCRIPTION
## Changelog Description

USD Asset Creators: Add `Asset` to the USD asset creator labels

## Additional review information

Our team sometimes missed that e.g. "assembly" referred to an asset assembly, and not the assembly/layout of e.g. a shot. As such, adding 'Asset' to the labels helped a lot to avoid that confusion.

However, it's a bit of personal taste perhaps - so please be opinionated in your review.

## Testing notes:

1. Check whether you like this or not.
