### PR TITLE
Publish: Use new workfiles API to increment current workfile.

### DIFF
--- a/client/ayon_houdini/plugins/publish/increment_current_file.py
+++ b/client/ayon_houdini/plugins/publish/increment_current_file.py
@@ -59,7 +59,7 @@ class IncrementCurrentFile(plugin.HoudiniContextPlugin):
                 filepath=new_filepath,
                 folder_entity=context.data["folderEntity"],
                 task_entity=context.data["taskEntity"],
-                description=f"Incremented by publishing.",
+                description="Incremented by publishing.",
                 # Optimize the save by reducing needed queries for context
                 prepared_data=SaveWorkfileOptionalData(
                     project_entity=context.data["projectEntity"],

--- a/client/ayon_houdini/plugins/publish/increment_current_file.py
+++ b/client/ayon_houdini/plugins/publish/increment_current_file.py
@@ -52,4 +52,21 @@ class IncrementCurrentFile(plugin.HoudiniContextPlugin):
             )
 
         new_filepath = version_up(current_file)
-        host.save_workfile(new_filepath)
+
+        if hasattr(host, "save_workfile_with_context"):
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
+            host.save_workfile_with_context(
+                filepath=new_filepath,
+                folder_entity=context.data["folderEntity"],
+                task_entity=context.data["taskEntity"],
+                description=f"Incremented by publishing.",
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+        else:
+            # Backwards compatibility
+            host.save_workfile(new_filepath)

--- a/client/ayon_houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_houdini/startup/MainMenuCommon.xml
@@ -19,8 +19,14 @@ return label
             <scriptItem id="ayon_version_up_workfile">
                 <label>Version Up Workfile</label>
                 <scriptCode><![CDATA[
-from ayon_core.pipeline.context_tools import version_up_current_workfile
-version_up_current_workfile()
+# Function 'save_next_version' was introduced in ayon-core 1.5.0
+try:
+    from ayon_core.pipeline.workfile import save_next_version
+except ImportError:
+    from ayon_core.pipeline.context_tools import (
+        version_up_current_workfile as save_next_version
+    )
+save_next_version()
 ]]></scriptCode>
                 <expression>
 from ayon_houdini.api.lib import is_version_up_workfile_menu_enabled


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Test with ayon-core 1.5.0 (and also backwards compatibility against older releases)

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
