### PR TITLE
Templated Workfile Build: make `fill_data` argument optional in `resolve_template_path`

### DIFF
--- a/client/ayon_houdini/api/workfile_template_builder.py
+++ b/client/ayon_houdini/api/workfile_template_builder.py
@@ -21,7 +21,7 @@ from .plugin import HoudiniCreator
 class HoudiniTemplateBuilder(AbstractTemplateBuilder):
     """Concrete implementation of AbstractTemplateBuilder for Houdini"""
 
-    def resolve_template_path(self, path, fill_data):
+    def resolve_template_path(self, path, fill_data=None):
         """Allows additional resolving over the template path using custom
         integration methods, like Houdini's expand string functionality.
 


### PR DESCRIPTION
## Changelog Description
resolve #280 
reported in https://community.ynput.io/t/houdini-templated-workfile-build-not-working/2653

## Testing notes:
1. Template builder should work in Houdini.
