### PR TITLE
Create HDA: Remove `maintain_selection` attribute

### DIFF
--- a/client/ayon_houdini/plugins/create/create_hda.py
+++ b/client/ayon_houdini/plugins/create/create_hda.py
@@ -154,7 +154,6 @@ class CreateHDA(plugin.HoudiniCreator):
     label = "Houdini Digital Asset (Hda)"
     product_type = "hda"
     icon = "gears"
-    maintain_selection = False
 
     def _check_existing(self, folder_path, product_name):
         # type: (str, str) -> bool


### PR DESCRIPTION
## Changelog Description

Remove `maintain_selection` attribute. It does nothing.

## Additional review information

This attribute only existed due to inheriting it from the legacy creators before switching to the new publisher (where it used to go through code like [this](https://github.com/ynput/ayon-core/blob/c2f3d8b114ecd93871029144bc81a77ad841758e/client/ayon_core/pipeline/create/legacy_create.py#L208)). However, I am pretty sure now it's unused.

Equivalent to:
- https://github.com/ynput/ayon-blender/pull/138
- https://github.com/ynput/ayon-nuke/pull/127

## Testing notes:

1. Creator should not be affected.
