### PR TITLE
Adapt to opmenu hierarchy of houdini `20.5`

### DIFF
--- a/client/ayon_houdini/startup/OPmenu.xml
+++ b/client/ayon_houdini/startup/OPmenu.xml
@@ -6,14 +6,14 @@
 <menuDocument>
     <menu>
         <!-- Operator type and asset options. -->
-        <subMenu id="opmenu.vhda_options_create">
-            <insertBefore>opmenu.unsynchronize</insertBefore>
-                <scriptItem id="opmenu.vhda_create_ayon">
-                    <insertAfter>opmenu.vhda_create</insertAfter>
-                    <label>Create New (AYON)...</label>
-                    <context>
-                    </context>
-                    <scriptCode>
+
+        <insertBefore>opmenu.unsynchronize</insertBefore>
+            <scriptItem id="opmenu.vhda_create_ayon">
+                <insertAfter>opmenu.vhda_create</insertAfter>
+                <label>Create Digital Asset (AYON)...</label>
+                <context>
+                </context>
+                <scriptCode>
 <![CDATA[
 from ayon_houdini.api.creator_node_shelves import create_interactive
 
@@ -22,8 +22,7 @@ if node not in hou.selectedNodes():
     node.setSelected(True)
 create_interactive("io.openpype.creators.houdini.hda", **kwargs)
 ]]>
-                     </scriptCode>
-                </scriptItem>
-        </subMenu>
+                </scriptCode>
+            </scriptItem>
     </menu>
 </menuDocument>


### PR DESCRIPTION
## Changelog Description
Adapt to opmenu hierarchy of houdini `20.5` as mentioned https://github.com/ynput/ayon-houdini/issues/195#issuecomment-3048146337

> <img alt="Image" width="682" height="498" src="https://private-user-images.githubusercontent.com/20871534/463618180-60a5d960-5dff-48aa-b278-1ef2d638847d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NTE5NjgzMDcsIm5iZiI6MTc1MTk2ODAwNywicGF0aCI6Ii8yMDg3MTUzNC80NjM2MTgxODAtNjBhNWQ5NjAtNWRmZi00OGFhLWIyNzgtMWVmMmQ2Mzg4NDdkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTA3MDglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwNzA4VDA5NDY0N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWVkZTY1OTkwOWVlMTMwM2VhYzE5YzI1YjJkOGU5MWFlZjgwNDUwOGI5YTZkZjYzNWJjYjRiMDk2NGFlYmJlZTQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0._jSyE4Ww6ivWEVmkF4Tk4Fm5sNB2eu90vmHSVVz-gfs">


## Testing notes:
you should see the same result as in  https://github.com/ynput/ayon-houdini/issues/195#issuecomment-3048146337
In 19.5 you'll get a warning
```
Order error: 'opmenu.vhda_create' and 'opmenu.vhda_create_ayon' don't have the same parent.
Cannot set order: element 'root_menu' has no parent.
Cannot set order: element 'root_menu' has no parent.
Error while parsing a menu definition file
 'C:/Program Files/Side Effects Software/sidefx_packages/SideFXLabs19.5/OPmenu.xml':
Cannot set order: element 'root_menu' has no parent.
Cannot set order: element 'root_menu' has no parent.
```
