### PR TITLE
Add Copernicus image file loader

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -292,7 +292,7 @@ def render_rop(ropnode, frame_range=None):
         raise RuntimeError("Render failed: {0}".format(exc))
 
 
-def imprint(node, data, update=False):
+def imprint(node, data, update=False, folder="Extra"):
     """Store attributes with value on a node
 
     Depending on the type of attribute it creates the correct parameter
@@ -312,6 +312,8 @@ def imprint(node, data, update=False):
         update (bool, optional): flag if imprint should update
             already existing data or leave them untouched and only
             add new.
+        folder (str, optional): The folder name to add new parms into.
+            Defaults to "Extra" due to legacy reasons.
 
     Returns:
         None
@@ -352,12 +354,12 @@ def imprint(node, data, update=False):
 
     # Add new parm templates
     if new_parm_templates:
-        parm_folder = parm_group.findFolder("Extra")
+        parm_folder = parm_group.findFolder(folder)
 
         # if folder doesn't exist yet, create one and append to it,
         # else append to existing one
         if not parm_folder:
-            parm_folder = hou.FolderParmTemplate("folder", "Extra")
+            parm_folder = hou.FolderParmTemplate("folder", folder)
             parm_folder.setParmTemplates(new_parm_templates)
             parm_group.append(parm_folder)
         else:
@@ -1428,11 +1430,11 @@ def find_active_network(category, default):
 
     Arguments:
         category (hou.NodeTypeCategory): The node network category type.
-        default (str): The default path to fallback to if no active pane
-            is found with the given category, e.g. "/obj"
+        default (Optional[str]): The default path to fallback to if no active
+            pane is found with the given category, e.g. "/obj"
 
     Returns:
-        hou.Node: The node network to return.
+        Optional[hou.Node]: The node network to return.
 
     """
     # Find network editors that are current tab of given category
@@ -1447,7 +1449,7 @@ def find_active_network(category, default):
             continue
 
         pwd = pane.pwd()
-        if pwd.type().category() != category:
+        if pwd.childTypeCategory() != category:
             continue
 
         if not pwd.isEditable():
@@ -1456,7 +1458,9 @@ def find_active_network(category, default):
         return pwd
 
     # Default to the fallback if no valid candidate was found
-    return hou.node(default)
+    if default is not None:
+        return hou.node(default)
+    return None
 
 
 def update_content_on_context_change():

--- a/client/ayon_houdini/plugins/load/load_image_copernicus.py
+++ b/client/ayon_houdini/plugins/load/load_image_copernicus.py
@@ -53,6 +53,14 @@ class ImageCopernicusLoader(plugin.HoudiniLoader):
     icon = "code-fork"
     color = "orange"
 
+    @classmethod
+    def apply_settings(cls, project_settings):
+        # Copernicus was introduced in Houdini 20.5.
+        if hou.applicationVersion() < (20, 5, 0):
+            cls.enabled = False
+            return None
+        return super().apply_settings(project_settings)
+
     def load(self, context, name=None, namespace=None, data=None):
         # Format file name, Houdini only wants forward slashes
         path = self.filepath_from_context(context)

--- a/server/settings/load.py
+++ b/server/settings/load.py
@@ -1,6 +1,14 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class EnabledLoadPluginsModel(BaseSettingsModel):
+    enabled: bool = SettingsField(
+        default=True,
+        title="Enabled",
+        description="Whether the plug-in is enabled"
+    )
+
+
 
 def camera_aperture_expression_enum_options():
     return [
@@ -50,6 +58,14 @@ class LoadPluginsModel(BaseSettingsModel):
     CameraLoader: CameraLoaderModel = SettingsField(
         default_factory=CameraLoaderModel,
         title="Load Camera (abc)")
+    ImageLoader: EnabledLoadPluginsModel = SettingsField(
+        default_factory=EnabledLoadPluginsModel,
+        title="Load Image (COP2)"
+    )
+    ImageCopernicusLoader: EnabledLoadPluginsModel = SettingsField(
+        default_factory=EnabledLoadPluginsModel,
+        title="Load Image (Copernicus)"
+    )
     LOPLoadAssetLoader: LoadUseAYONEntityURIModel = SettingsField(
         default_factory=LoadUseAYONEntityURIModel,
         title="LOP Load Asset")


### PR DESCRIPTION
## Changelog Description

Add Copernicus image file loader

## Additional review information

Note that it tries to load in an active Copernicus network, because it doesn't seem that Copernicus has the equivalent of an Object Merge node so there's little use in having the loaded content inside the `AYON_CONTAINERS` object.

Also added settings to allow disabling certain Loader plug-ins:

<img width="266" height="77" alt="image" src="https://github.com/user-attachments/assets/fe6bcf0f-4ffd-41a2-9447-32f22d39f67a" />

## Testing notes:

1. Loading should work
2. Update should work
3. Remove should work.
