### PR TITLE
Fix Houdini 20.5+ COP2 publish validation

### DIFF
--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -11,6 +11,7 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
 
     identifier = "io.openpype.creators.houdini.imagesequence"
     label = "Composite (Image Sequence)"
+    description = "Create legacy COP2 ROP to render image sequence"
     product_type = "imagesequence"
     icon = "gears"
 

--- a/client/ayon_houdini/plugins/publish/validate_cop_output_node.py
+++ b/client/ayon_houdini/plugins/publish/validate_cop_output_node.py
@@ -8,17 +8,17 @@ from ayon_houdini.api import plugin
 
 
 class ValidateCopOutputNode(plugin.HoudiniInstancePlugin):
-    """Validate the instance COP Output Node.
+    """Validate the instance COP2 Output Node.
 
     This will ensure:
-        - The COP Path is set.
-        - The COP Path refers to an existing object.
-        - The COP Path node is a COP node.
+        - The COP2 Path is set.
+        - The COP2 Path refers to an existing object.
+        - The COP2 Path node is a COP node.
     """
 
     order = pyblish.api.ValidatorOrder
     families = ["imagesequence"]
-    label = "Validate COP Output Node"
+    label = "Validate COP2 Output Node"
 
     def process(self, instance):
 
@@ -29,9 +29,9 @@ class ValidateCopOutputNode(plugin.HoudiniInstancePlugin):
                 "See plug-in log for details.".format(invalid[0].path()),
                 title=self.label,
                 description=(
-                    "### Invalid COP output node\n\n"
+                    "### Invalid COP2 output node\n\n"
                     "The output node path for the instance must be set to a "
-                    "valid COP node path.\n\nSee the log for more details."
+                    "valid COP2 node path.\n\nSee the log for more details."
                 )
             )
 
@@ -42,8 +42,8 @@ class ValidateCopOutputNode(plugin.HoudiniInstancePlugin):
         if not output_node:
             node = hou.node(instance.data.get("instance_node"))
             cls.log.error(
-                "COP Output node in '%s' does not exist. "
-                "Ensure a valid COP output path is set." % node.path()
+                "COP2 Output node in '%s' does not exist. "
+                "Ensure a valid COP2 output path is set." % node.path()
             )
 
             return [node]
@@ -60,8 +60,8 @@ class ValidateCopOutputNode(plugin.HoudiniInstancePlugin):
         node_category_name = output_node.type().category().name()
         if not isinstance(output_node, class_type):
             cls.log.error(
-                "Output node %s is not a COP node. "
-                "COP Path must point to a COP node, "
+                "Output node %s is not a COP2 node. "
+                "COP2 Path must point to a COP2 node, "
                 "instead found category type: %s",
                 output_node.path(), node_category_name
             )


### PR DESCRIPTION
## Changelog Description

Fix #270: In Hou 20.5+ allow COP2 validation to pass

## Additional review information

Houdini 20.5+ renamed the `hou.CopNode` class name to `hou.Cop2Node` for the legacy COP nodes - the `hou.CopNode` now refers to newer copernicus node types.

## Testing notes:

1. Publish COP network should work from Houdini 20.5+ (and also in older releases)
