### PR TITLE
Add support to publish Copernicus comps

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -90,6 +90,9 @@ def get_output_parameter(node):
         return node.parm("sopoutput")
     elif node_type == "comp":
         return node.parm("copoutput")
+    elif node_type in {"image", "image_rop"}:
+        # Copernicus
+        return node.parm("copoutput")
     elif node_type in {"karma", "opengl", "flipbook"}:
         return node.parm("picture")
     elif node_type == "ifd":  # Mantra

--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -11,9 +11,9 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
 
     identifier = "io.openpype.creators.houdini.imagesequence"
     label = "Composite (COP2)"
-    description = "Create legacy COP2 ROP to render image sequence"
+    description = "Render legacy COP2 ROP to image sequence"
     product_type = "imagesequence"
-    icon = "gears"
+    icon = "fa5.eye"
 
     ext = ".exr"
 

--- a/client/ayon_houdini/plugins/create/create_copernicus.py
+++ b/client/ayon_houdini/plugins/create/create_copernicus.py
@@ -6,22 +6,21 @@ from ayon_core.pipeline import CreatorError
 import hou
 
 
-class CreateCompositeSequence(plugin.HoudiniCreator):
-    """Composite ROP to Image Sequence"""
+class CreateCopernicusROP(plugin.HoudiniCreator):
+    """Copernicus ROP to Image Sequence"""
 
-    identifier = "io.openpype.creators.houdini.imagesequence"
-    label = "Composite (COP2)"
-    product_type = "imagesequence"
-    icon = "gears"
+    identifier = "io.ayon.creators.houdini.copernicus"
+    label = "Composite (Copernicus)"
+    description = "Render using the Copernicus Image ROP."
+    product_type = "render"
+    icon = "fa5.eye"
 
     ext = ".exr"
 
     def create(self, product_name, instance_data, pre_create_data):
-        import hou  # noqa
+        instance_data["node_type"] = "image"
 
-        instance_data.update({"node_type": "comp"})
-
-        instance = super(CreateCompositeSequence, self).create(
+        instance = super().create(
             product_name,
             instance_data,
             pre_create_data)
@@ -35,7 +34,6 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
             "trange": 1,
             "copoutput": filepath
         }
-
         if self.selected_nodes:
             if len(self.selected_nodes) > 1:
                 raise CreatorError("More than one item selected.")
@@ -49,12 +47,14 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
         instance_node.parm("f1").setExpression("$FSTART")
         instance_node.parm("f2").setExpression("$FEND")
 
-        # Lock any parameters in this list
-        to_lock = ["prim_to_detail_pattern"]
-        self.lock_parameters(instance_node, to_lock)
-
     def get_network_categories(self):
         return [
             hou.ropNodeTypeCategory(),
             hou.cop2NodeTypeCategory()
+        ]
+
+    def get_publish_families(self):
+        return [
+            "render",
+            "image_rop",
         ]

--- a/client/ayon_houdini/plugins/create/create_copernicus.py
+++ b/client/ayon_houdini/plugins/create/create_copernicus.py
@@ -28,7 +28,7 @@ class CreateCopernicusROP(plugin.HoudiniCreator):
         instance_node = hou.node(instance.get("instance_node"))
         filepath = "{}{}".format(
             hou.text.expandString("$HIP/pyblish/"),
-            "{}.$F4{}".format(product_name, self.ext)
+            f"{product_name}.$F4{self.ext}"
         )
         parms = {
             "trange": 1,

--- a/client/ayon_houdini/plugins/create/create_copernicus.py
+++ b/client/ayon_houdini/plugins/create/create_copernicus.py
@@ -17,6 +17,10 @@ class CreateCopernicusROP(plugin.HoudiniCreator):
 
     ext = ".exr"
 
+    # Copernicus was introduced in Houdini 20.5 so we only enable this
+    # creator if the Houdini version is 20.5 or higher.
+    enabled = hou.applicationVersion() >= (20, 5, 0)
+
     def create(self, product_name, instance_data, pre_create_data):
         instance_data["node_type"] = "image"
 

--- a/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -16,7 +16,7 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
     label = "Collect Frames"
     families = ["camera", "vdbcache", "imagesequence", "ass",
                 "redshiftproxy", "review", "pointcache", "fbx",
-                "model", "bgeo"]
+                "model", "bgeo", "image_rop"]
 
     def process(self, instance):
 

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -12,7 +12,8 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
     order = pyblish.api.ExtractorOrder
 
     families = ["abc", "camera", "bgeo", "pointcache", "fbx",
-                "vdbcache", "ass", "redshiftproxy", "mantraifd"]
+                "vdbcache", "ass", "redshiftproxy", "mantraifd",
+                "image_rop"]
     targets = ["local", "remote"]
 
     def process(self, instance: pyblish.api.Instance):


### PR DESCRIPTION
## Changelog Description

Add support to publish Copernicus comps as "render" product type.

## Additional review information

Fix #269: Add support to render Copernicus comps (AY-7895)

- [ ] There are no validations implemented around the `coppath`. Is this problematic?
- [ ] Should this have a `review` toggle because it's "render" product type?

## Testing notes:

1. Create a Copernicus graph
2. Publish the output image.
