### PR TITLE
Support Mandatory Workfiles

### DIFF
--- a/client/ayon_houdini/plugins/create/create_workfile.py
+++ b/client/ayon_houdini/plugins/create/create_workfile.py
@@ -7,12 +7,14 @@ from ayon_core.pipeline import CreatedInstance, AutoCreator
 
 class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
     """Workfile auto-creator."""
+    settings_category = "houdini"
     identifier = "io.openpype.creators.houdini.workfile"
     label = "Workfile"
     product_type = "workfile"
     icon = "fa5.file"
 
     default_variant = "Main"
+    is_mandatory = False
 
     def create(self):
         variant = self.default_variant
@@ -78,6 +80,9 @@ class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
         context_node = self.host.get_context_node()
         if not context_node:
             context_node = self.host.create_context_node()
+
+        if hasattr(current_instance, "set_mandatory"):
+            current_instance.set_mandatory(self.is_mandatory)
 
         workfile_data = {"workfile": current_instance.data_to_store()}
         imprint(context_node, workfile_data)

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -76,6 +76,17 @@ class CreateUSDRenderModel(CreatorModel):
         ))
 
 
+class WorkfileModel(BaseSettingsModel):
+    is_mandatory: bool = SettingsField(
+        default=False,
+        title="Mandatory workfile",
+        description=(
+            "Workfile cannot be disabled by user in UI."
+            " Requires core addon 1.4.1 or newer."
+        )
+    )
+
+
 class CreatePluginsModel(BaseSettingsModel):
     render_rops_use_legacy_product_type: bool = SettingsField(
         False,
@@ -150,6 +161,9 @@ class CreatePluginsModel(BaseSettingsModel):
     CreateVrayROP: CreatorModel = SettingsField(
         default_factory=CreatorModel,
         title="Create VRay ROP")
+    CreateWorkfile: WorkfileModel = SettingsField(
+        default_factory=WorkfileModel,
+        title="Create Workfile")
 
 
 DEFAULT_HOUDINI_CREATE_SETTINGS = {


### PR DESCRIPTION
## Changelog Description
This supports marking workfiles as mandatory in order to restrict users from disabling workfile publishes.

## Additional review information
Depends on this PR here:
https://github.com/ynput/ayon-core/pull/1360

Adapted from this PR:
https://github.com/ynput/ayon-maya/pull/312

⚠️ this requires you to build/upload the addon to your AYON instance as server settings get changed.

## Testing notes:
1. build/upload the addon
2. enable manadatory workfiles via `ayon+settings://houdini/create/CreateWorkfile/is_mandatory`
3. check that the Workfile Toggle is gone from the Publisher
