### PR TITLE
Colorspaces: Remove handling `<USE_DISPLAY_NAME>`

### DIFF
--- a/client/ayon_houdini/api/colorspace.py
+++ b/client/ayon_houdini/api/colorspace.py
@@ -63,6 +63,4 @@ def get_default_display_view_colorspace() -> str:
         display=prefs["display"],
         view=prefs["view"]
     )
-    if colorspace == "<USE_DISPLAY_NAME>":
-        colorspace = prefs["display"]
     return colorspace


### PR DESCRIPTION
## Changelog Description
resolve #299

## Testing notes:
similar to https://github.com/ynput/ayon-core/pull/1268
1. Set colorspace config to newer config v1.3 e.g. 
    <img width="541" height="48" alt="image" src="https://github.com/user-attachments/assets/9c7ee80f-59d0-49f0-ac7b-f259c1bb197e" />
2. Set color display and view to
    <img width="297" height="38" alt="image" src="https://github.com/user-attachments/assets/650885a6-47fb-4073-b66f-a37e02ad2940" />
3. when creating review instance, its colorspace should be the display name.
    <img width="448" height="39" alt="image" src="https://github.com/user-attachments/assets/2796e305-eab2-454a-9e27-f44e60e8b581" />
