### PR TITLE
USD contribution workflow: prefix folder names with `_` if starting with a digit to avoid invalid prim names in USD data

### DIFF
--- a/client/ayon_houdini/api/usd.py
+++ b/client/ayon_houdini/api/usd.py
@@ -12,6 +12,14 @@ from pxr import Usd, Sdf, Tf, Vt, UsdRender
 
 log = logging.getLogger(__name__)
 
+# Expression to take last part of the folder path as default prim, but if
+# it starts with a digit then prefix it with underscore `_` matching the
+# behavior of `get_standard_default_prim_name` from AYON core.
+DEFAULT_PRIM_EXPRESSION: str = (
+    '/`ifs(strmatch("[0123456789]", strsplit(chs("folderPath"), "/", -1)[0])'
+    ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
+)
+
 
 def add_usd_output_processor(ropnode, processor):
     """Add USD Output Processor to USD Rop node.

--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -3,6 +3,7 @@
 import inspect
 
 from ayon_houdini.api import plugin
+from ayon_houdini.api.usd import DEFAULT_PRIM_EXPRESSION
 from ayon_core.lib import EnumDef
 
 import hou
@@ -96,10 +97,7 @@ class CreateUSDModel(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": (
-            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
-            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
-        ),
+        "defaultprim": DEFAULT_PRIM_EXPRESSION,
     }
 
     def get_detail_description(self):
@@ -121,10 +119,7 @@ class CreateUSDAssembly(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": (
-            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
-            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
-        ),
+        "defaultprim": DEFAULT_PRIM_EXPRESSION,
 
     }
 
@@ -148,10 +143,7 @@ class CreateUSDGroom(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": (
-            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
-            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
-        ),
+        "defaultprim": DEFAULT_PRIM_EXPRESSION,
     }
 
     def get_detail_description(self):
@@ -177,10 +169,7 @@ class CreateUSDLook(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": (
-            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
-            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
-        ),
+        "defaultprim": DEFAULT_PRIM_EXPRESSION,
     }
 
     def get_detail_description(self):

--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -96,7 +96,10 @@ class CreateUSDModel(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": '/`strsplit(chs("folderPath"), "/", -1)`',
+        "defaultprim": (
+            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
+            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
+        ),
     }
 
     def get_detail_description(self):
@@ -118,7 +121,11 @@ class CreateUSDAssembly(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": '/`strsplit(chs("folderPath"), "/", -1)`',
+        "defaultprim": (
+            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
+            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
+        ),
+
     }
 
     def get_detail_description(self):
@@ -141,7 +148,10 @@ class CreateUSDGroom(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": '/`strsplit(chs("folderPath"), "/", -1)`',
+        "defaultprim": (
+            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
+            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
+        ),
     }
 
     def get_detail_description(self):
@@ -167,7 +177,10 @@ class CreateUSDLook(CreateUSD):
     additional_parameters = {
         # Set the 'default prim' by default to the folder name being
         # published to
-        "defaultprim": '/`strsplit(chs("folderPath"), "/", -1)`',
+        "defaultprim": (
+            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
+            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
+        ),
     }
 
     def get_detail_description(self):

--- a/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
@@ -8,6 +8,7 @@ from ayon_core.pipeline.publish import RepairAction, OptionalPyblishPluginMixin
 from ayon_core.pipeline.usdlib import get_standard_default_prim_name
 
 from ayon_houdini.api.action import SelectROPAction
+from ayon_houdini.api.usd import DEFAULT_PRIM_EXPRESSION
 from ayon_houdini.api import plugin
 
 
@@ -75,10 +76,7 @@ class ValidateUSDAssetContributionDefaultPrim(plugin.HoudiniInstancePlugin,
     @classmethod
     def repair(cls, instance):
         rop_node = hou.node(instance.data["instance_node"])
-        rop_node.parm("defaultprim").set(
-            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
-            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
-        )
+        rop_node.parm("defaultprim").set(DEFAULT_PRIM_EXPRESSION)
 
     @staticmethod
     def get_attr_values_from_data_for_plugin_name(

--- a/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
@@ -76,7 +76,8 @@ class ValidateUSDAssetContributionDefaultPrim(plugin.HoudiniInstancePlugin,
     def repair(cls, instance):
         rop_node = hou.node(instance.data["instance_node"])
         rop_node.parm("defaultprim").set(
-            "/`strsplit(chs(\"folderPath\"), \"/\", -1)`"
+            '/`ifs(strmatch("[0-9]", strsplit(chs("folderPath"), "/", -1)[0])'
+            ', "_", "")``strsplit(chs("folderPath"), "/", -1)`'
         )
 
     @staticmethod

--- a/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
+++ b/client/ayon_houdini/plugins/publish/validate_usd_asset_contribution_default_prim.py
@@ -5,6 +5,7 @@ import pyblish.api
 
 from ayon_core.pipeline import PublishValidationError
 from ayon_core.pipeline.publish import RepairAction, OptionalPyblishPluginMixin
+from ayon_core.pipeline.usdlib import get_standard_default_prim_name
 
 from ayon_houdini.api.action import SelectROPAction
 from ayon_houdini.api import plugin
@@ -59,7 +60,9 @@ class ValidateUSDAssetContributionDefaultPrim(plugin.HoudiniInstancePlugin,
                 description=self.get_description()
             )
 
-        folder_name = instance.data["folderPath"].rsplit("/", 1)[-1]
+        folder_name = get_standard_default_prim_name(
+            instance.data["folderPath"]
+        )
         if not default_prim.lstrip("/") == folder_name:
             raise PublishValidationError(
                 f"Default prim specified on ROP node does not match the"


### PR DESCRIPTION
## Changelog Description

Follow up PR to https://github.com/ynput/ayon-core/pull/1535

## Testing notes:
1. Create a usd rop, the folder name should be prefixed with `_` if folder name starts with number.
2. Remove the value of default prim, trigger validation, repair action should add default prim expr that leads to the same value from previous point.
