### PR TITLE
USD ROP: Compute correctly which USD Value Clips will actually be written to disk

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_value_clips.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_value_clips.py
@@ -41,8 +41,10 @@ def get_clip_frames_in_frame_range(
 
     # Case 2: Has end frame, no loop - clip plays once
     if not loop:
-        actual_clip_end = clip_end + 1  # Houdini exports an additional frame when not looping
-        # Intersection of [clip_start, actual_clip_end] and [range_start, range_end]
+        # Houdini exports an additional frame when not looping
+        actual_clip_end = clip_end + 1
+        # Intersection of [clip_start, actual_clip_end]
+        # and [range_start, range_end]
         intersection_start = max(clip_start, range_start)
         intersection_end = min(actual_clip_end, range_end)
         if intersection_start <= intersection_end:


### PR DESCRIPTION
## Changelog Description

USD ROP: Compute correctly which USD Value Clips will actually be written to disk

## Additional review information

Fix #259 and fix #309
Without this PR the expected clip files to be saved on disk is incorectly calculated.

## Testing notes:
1. Publish of value clips should correctly consider the actual frames to be written.