### PR TITLE
Update context vars: report path when failing to create it

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -1027,7 +1027,7 @@ def update_houdini_vars_context():
             except OSError as e:
                 if e.errno != errno.EEXIST:
                     print(
-                        f"Failed to create ${var} dir at {new}. "
+                        f"Failed to create ${var} dir at '{new}'. "
                         "Maybe due to insufficient permissions."
                     )
 


### PR DESCRIPTION
## Changelog Description

In case of failure to create folder for context specific houdini-variables report the filepath which failed to get created.

## Additional review information

Makes it easier to debug the issue.

## Testing notes:

1. Check code changes
