### PR TITLE
HDA version picker: Ensure versions are sorted like in Loader UI with hero just below the non-hero version

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -169,7 +169,13 @@ def get_available_versions(
         fields={"version"},
         hero=include_hero,
     )
-    for version in reversed(list(versions)):
+    def _sort_versions(version: dict) -> float:
+        # Hero versions are negative and should be just below their non-hero
+        # positive equivalents, like 1, 2, 3, -4, 4.
+        num: int = version["version"]
+        return float(abs(num) - (int(num < 0) * 0.5))
+
+    for version in sorted(versions, key=_sort_versions, reverse=True):
         all_version_names.append(version["version"])
     return all_version_names
 


### PR DESCRIPTION
## Changelog Description

HDA version picker: Ensure versions are sorted like in Loader UI with hero just below the non-hero version

## Additional review information

After merging https://github.com/ynput/ayon-houdini/pull/321 I just noticed @MustafaJafar 's screenshot had an odd place in the list for the hero version in this screenshot:
<img alt="image" width="2000" height="776" src="https://private-user-images.githubusercontent.com/20871534/517581844-c06e11fe-7e52-4feb-84ac-45a03d8855f2.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NjM3NTc0NjYsIm5iZiI6MTc2Mzc1NzE2NiwicGF0aCI6Ii8yMDg3MTUzNC81MTc1ODE4NDQtYzA2ZTExZmUtN2U1Mi00ZmViLTg0YWMtNDVhMDNkODg1NWYyLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTExMjElMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUxMTIxVDIwMzI0NlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWNlZjc0MTc2ZmJkZTI4MmVlMmQzZTg0OWY3Y2FlMmRhZGQ2YTAyN2JmZWU5ZTNhODYzOWEzNjA1ZWY2NTZiNDcmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.0LbeRaB-1NVpc3YVg4aUgZeLqvoVQE3jnpaBVWSRXVQ">

This PR should make the sorting similar to the Loader UI.

## Testing notes:
1. Sorting should keep the hero version just below the regular version.