### PR TITLE
Render: Fix OCIO display/view data not being collected for local render instances - Follow up

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_review_data.py
+++ b/client/ayon_houdini/plugins/publish/collect_review_data.py
@@ -10,7 +10,8 @@ class CollectHoudiniReviewData(plugin.HoudiniInstancePlugin):
     # This specific order value is used so that
     # this plugin runs after CollectRopFrameRange
     # Also after CollectLocalRenderInstances
-    order = pyblish.api.CollectorOrder + 0.13
+    # Also before CollectAssetHandles
+    order = pyblish.api.CollectorOrder + 0.152
     families = ["review"]
 
     def process(self, instance):


### PR DESCRIPTION
## Changelog Description
Fixes lack of fps data for reviews for render instances
`CollectHoudiniReviewData`: Tweak `order` to be after `CollectLocalRenderInstances`

## Additional review information
follow up to #324 and #325

## Testing notes:
1. start with this step
2. follow this step
