### PR TITLE
Product names: Update product name functionality

### DIFF
--- a/client/ayon_houdini/plugins/create/create_fbx.py
+++ b/client/ayon_houdini/plugins/create/create_fbx.py
@@ -122,30 +122,6 @@ class CreateFBX(plugin.HoudiniCreator):
             format_ascii,
         ] + self.get_instance_attr_defs()
 
-    def get_dynamic_data(
-        self,
-        project_name,
-        folder_entity,
-        task_entity,
-        variant,
-        host_name,
-        instance
-    ):
-        """
-        The default product name templates for Unreal include {asset} and thus
-        we should pass that along as dynamic data.
-        """
-        dynamic_data = super().get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-        dynamic_data["asset"] = folder_entity["name"]
-        return dynamic_data
-
     def get_selection(self):
         """Selection Logic.
 

--- a/client/ayon_houdini/plugins/create/create_hda.py
+++ b/client/ayon_houdini/plugins/create/create_hda.py
@@ -347,7 +347,9 @@ class CreateHDA(plugin.HoudiniCreator):
         task_entity,
         variant,
         host_name,
-        instance
+        instance,
+        project_entity=None,
+        product_type=None,
     ):
         """
         Pass product name from product name templates as dynamic data.

--- a/client/ayon_houdini/plugins/create/create_hda.py
+++ b/client/ayon_houdini/plugins/create/create_hda.py
@@ -352,23 +352,12 @@ class CreateHDA(plugin.HoudiniCreator):
         """
         Pass product name from product name templates as dynamic data.
         """
-        dynamic_data = super(CreateHDA, self).get_dynamic_data(
-            project_name,
-            folder_entity,
-            task_entity,
-            variant,
-            host_name,
-            instance
-        )
-
-        dynamic_data.update(
-            {
-                "asset": folder_entity["name"],
-                "folder": {
-                            "label": folder_entity["label"],
-                            "name": folder_entity["name"]
-                }
+        # TODO remove when ayon-core does support folder label to be used
+        #   in product name templates
+        return {
+            "folder": {
+                "label": folder_entity["label"],
+                "name": folder_entity["name"],
+                "type": folder_entity["folderType"],
             }
-        )
-
-        return dynamic_data
+        }

--- a/client/ayon_houdini/plugins/create/create_workfile.py
+++ b/client/ayon_houdini/plugins/create/create_workfile.py
@@ -49,15 +49,6 @@ class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
                 "variant": variant,
             }
 
-            data.update(
-                self.get_dynamic_data(
-                    project_name,
-                    folder_entity,
-                    task_entity,
-                    variant,
-                    host_name,
-                    current_instance)
-            )
             self.log.info("Auto-creating workfile instance...")
             current_instance = CreatedInstance(
                 product_type=self.product_type,

--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -114,7 +114,7 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
 
         context = instance.context
         # In ideal case this plugin should run after plugin
-        #   "Collect instance anatomy data" but because is running before
+        #   "CollectAnatomyInstanceData" but because is running before
         #   the entities has to be fetched here
         project_name = context.data["projectName"]
         folder_path = instance.data["folderPath"]

--- a/client/ayon_houdini/plugins/publish/collect_usd_layers.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_layers.py
@@ -2,6 +2,7 @@ import copy
 import os
 import re
 
+import ayon_api
 import pyblish.api
 
 from ayon_core.pipeline import KnownPublishError
@@ -111,9 +112,31 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
         # Store on the instance
         instance.data["usdConfiguredSavePaths"] = save_layers
 
+        context = instance.context
+        # In ideal case this plugin should run after plugin
+        #   "Collect instance anatomy data" but because is running before
+        #   the entities has to be fetched here
+        project_name = context.data["projectName"]
+        folder_path = instance.data["folderPath"]
+        task_name = instance.data.get("task")
+        folder_entity = instance.data.get("folderEntity")
+        task_entity = instance.data.get("taskEntity")
+        if not folder_entity and folder_path:
+            folder_entity = ayon_api.get_folder_by_path(
+                project_name, folder_path
+            )
+            instance.data["folderEntity"] = folder_entity
+
+        if not task_entity and folder_entity and task_name:
+            task_entity = ayon_api.get_task_by_name(
+                project_name,
+                folder_entity["id"],
+                task_name
+            )
+            instance.data["taskEntity"] = task_entity
+
         # Create configured layer instances so User can disable updating
         # specific configured layers for publishing.
-        context = instance.context
         for layer, save_path, creator_node in save_layers:
             name = os.path.basename(save_path)
             layer_inst = context.create_instance(name)
@@ -138,25 +161,50 @@ class CollectUsdLayers(plugin.HoudiniInstancePlugin):
             layer_inst.data["usd_layer"] = layer
             layer_inst.data["usd_layer_save_path"] = save_path
 
-            project_name = context.data["projectName"]
+            product_base_type = "usd"
             variant_base = instance.data["variant"]
+
+            get_product_name_kwargs = {}
+            if getattr(get_product_name, "use_entities", False):
+                get_product_name_kwargs.update({
+                    "folder_entity": folder_entity,
+                    "task_entity": task_entity,
+                    "product_base_type": product_base_type,
+                })
+            else:
+                task_name = task_type = None
+                if task_entity:
+                    task_name = task_entity["name"]
+                    task_type = task_entity["taskType"]
+                get_product_name_kwargs.update({
+                    "task_name": task_name,
+                    "task_type": task_type,
+                })
+
             product_name = get_product_name(
-                project_name=project_name,
-                # TODO: This should use task from `instance`
-                task_name=context.data["anatomyData"]["task"]["name"],
-                task_type=context.data["anatomyData"]["task"]["type"],
-                host_name=context.data["hostName"],
-                product_type="usd",
+                project_name=instance.context.data["projectName"],
+                host_name=instance.context.data["hostName"],
+                product_type=instance.data["productType"],
                 variant=variant_base + "_" + variant,
-                project_settings=context.data["project_settings"]
+                project_settings=context.data["project_settings"],
+                project_entity=context.data["projectEntity"],
+                dynamic_data={
+                    "folder": {
+                        "label": folder_entity["label"],
+                        "name": folder_entity["name"],
+                        "type": folder_entity["folderType"]
+                    },
+                },
+                **get_product_name_kwargs,
             )
 
             label = "{0} -> {1}".format(instance.data["name"], product_name)
-            family = "usd"
-            layer_inst.data["family"] = family
-            layer_inst.data["families"] = [family]
+
+            layer_inst.data["family"] = product_base_type
+            layer_inst.data["families"] = [product_base_type]
+            layer_inst.data["productBaseType"] = product_base_type
+            layer_inst.data["productType"] = product_base_type
             layer_inst.data["productName"] = product_name
-            layer_inst.data["productType"] = instance.data["productType"]
             layer_inst.data["label"] = label
             layer_inst.data["folderPath"] = instance.data["folderPath"]
             layer_inst.data["task"] = instance.data.get("task")

--- a/client/ayon_houdini/plugins/publish/validate_product_name.py
+++ b/client/ayon_houdini/plugins/publish/validate_product_name.py
@@ -48,27 +48,46 @@ class ValidateProductName(plugin.HoudiniInstancePlugin,
         rop_node = hou.node(instance.data["instance_node"])
 
         # Check product name
+        project_entity = instance.context.data["projectEntity"]
+        project_settings = instance.context.data["project_settings"]
         folder_entity = instance.data["folderEntity"]
         task_entity = instance.data["taskEntity"]
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+
+        get_product_name_kwargs = {}
+        if getattr(get_product_name, "use_entities", False):
+            get_product_name_kwargs.update({
+                "folder_entity": folder_entity,
+                "task_entity": task_entity,
+                "product_base_type": product_base_type,
+            })
+        else:
+            task_name = task_type = None
+            if task_entity:
+                task_name = task_entity["name"]
+                task_type = task_entity["taskType"]
+            get_product_name_kwargs.update({
+                "task_name": task_name,
+                "task_type": task_type,
+            })
+
         product_name = get_product_name(
             project_name=instance.context.data["projectName"],
-            task_name=task_name,
-            task_type=task_type,
             host_name=instance.context.data["hostName"],
             product_type=instance.data["productType"],
             variant=instance.data["variant"],
+            project_entity=project_entity,
+            project_settings=project_settings,
             dynamic_data={
                 "folder": {
                     "label": folder_entity["label"],
                     "name": folder_entity["name"],
+                    "type": folder_entity["folderType"]
                 },
-                # Backwards compatibility
-                "asset": folder_entity["name"],
             },
+            **get_product_name_kwargs,
         )
 
         if instance.data.get("productName") != product_name:
@@ -83,26 +102,47 @@ class ValidateProductName(plugin.HoudiniInstancePlugin,
         rop_node = hou.node(instance.data["instance_node"])
 
         # Check product name
+        project_entity = instance.context.data["projectEntity"]
+        project_settings = instance.context.data["project_settings"]
         folder_entity = instance.data["folderEntity"]
         task_entity = instance.data["taskEntity"]
-        task_name = task_type = None
-        if task_entity:
-            task_name = task_entity["name"]
-            task_type = task_entity["taskType"]
+
+        product_base_type = instance.data.get("productBaseType")
+        if not product_base_type:
+            product_base_type = instance.data["productType"]
+
+        get_product_name_kwargs = {}
+        if getattr(get_product_name, "use_entities", False):
+            get_product_name_kwargs.update({
+                "folder_entity": folder_entity,
+                "task_entity": task_entity,
+                "product_base_type": product_base_type,
+            })
+        else:
+            task_name = task_type = None
+            if task_entity:
+                task_name = task_entity["name"]
+                task_type = task_entity["taskType"]
+            get_product_name_kwargs.update({
+                "task_name": task_name,
+                "task_type": task_type,
+            })
+
         product_name = get_product_name(
             project_name=instance.context.data["projectName"],
-            task_name=task_name,
-            task_type=task_type,
             host_name=instance.context.data["hostName"],
             product_type=instance.data["productType"],
             variant=instance.data["variant"],
+            project_entity=project_entity,
+            project_settings=project_settings,
             dynamic_data={
-                "asset": folder_entity["name"],
                 "folder": {
-                            "label": folder_entity["label"],
-                            "name": folder_entity["name"]
-                            }
-                }
+                    "label": folder_entity["label"],
+                    "name": folder_entity["name"],
+                    "type": folder_entity["folderType"]
+                },
+            },
+            **get_product_name_kwargs,
         )
 
         instance.data["productName"] = product_name

--- a/client/ayon_houdini/plugins/publish/validate_product_name.py
+++ b/client/ayon_houdini/plugins/publish/validate_product_name.py
@@ -47,48 +47,7 @@ class ValidateProductName(plugin.HoudiniInstancePlugin,
 
         rop_node = hou.node(instance.data["instance_node"])
 
-        # Check product name
-        project_entity = instance.context.data["projectEntity"]
-        project_settings = instance.context.data["project_settings"]
-        folder_entity = instance.data["folderEntity"]
-        task_entity = instance.data["taskEntity"]
-        product_base_type = instance.data.get("productBaseType")
-        if not product_base_type:
-            product_base_type = instance.data["productType"]
-
-        get_product_name_kwargs = {}
-        if getattr(get_product_name, "use_entities", False):
-            get_product_name_kwargs.update({
-                "folder_entity": folder_entity,
-                "task_entity": task_entity,
-                "product_base_type": product_base_type,
-            })
-        else:
-            task_name = task_type = None
-            if task_entity:
-                task_name = task_entity["name"]
-                task_type = task_entity["taskType"]
-            get_product_name_kwargs.update({
-                "task_name": task_name,
-                "task_type": task_type,
-            })
-
-        product_name = get_product_name(
-            project_name=instance.context.data["projectName"],
-            host_name=instance.context.data["hostName"],
-            product_type=instance.data["productType"],
-            variant=instance.data["variant"],
-            project_entity=project_entity,
-            project_settings=project_settings,
-            dynamic_data={
-                "folder": {
-                    "label": folder_entity["label"],
-                    "name": folder_entity["name"],
-                    "type": folder_entity["folderType"]
-                },
-            },
-            **get_product_name_kwargs,
-        )
+        product_name = cls._get_product_name(instance)
 
         if instance.data.get("productName") != product_name:
             cls.log.error(
@@ -101,6 +60,18 @@ class ValidateProductName(plugin.HoudiniInstancePlugin,
     def repair(cls, instance):
         rop_node = hou.node(instance.data["instance_node"])
 
+        product_name = cls._get_product_name(instance)
+
+        instance.data["productName"] = product_name
+        rop_node.parm("AYON_productName").set(product_name)
+
+        cls.log.debug(
+            "Product name on rop node '%s' has been set to '%s'.",
+            rop_node.path(), product_name
+        )
+
+    @staticmethod
+    def _get_product_name(instance):
         # Check product name
         project_entity = instance.context.data["projectEntity"]
         project_settings = instance.context.data["project_settings"]
@@ -144,14 +115,7 @@ class ValidateProductName(plugin.HoudiniInstancePlugin,
             },
             **get_product_name_kwargs,
         )
-
-        instance.data["productName"] = product_name
-        rop_node.parm("AYON_productName").set(product_name)
-
-        cls.log.debug(
-            "Product name on rop node '%s' has been set to '%s'.",
-            rop_node.path(), product_name
-        )
+        return product_name
 
     @classmethod
     def convert_attribute_values(


### PR DESCRIPTION
## Changelog Description
Use new signature of `get_product_name` function and update signature to use new `product_type` argument where needed.

## Additional review information
The signature of `get_product_name` did change in past and is reaching end of life thus should not be used anymore. With PR https://github.com/ynput/ayon-core/pull/1656 it is also added `product_type` to `get_product_name` and `get_dynamic_data` methodes on create plugins.

Remove `get_dynamic_data` that were adding `"asset"` key, which is long deprecated key from OpenPype and `folder[name]` is already available in default ayon-core at this moment. There is one `get_dynamic_data` which actually returns folder data but cannot be removed because ayon-core's implementation does not add `"label"` to the folder template, created PR to fix it https://github.com/ynput/ayon-core/pull/1655 .

Workfile creator was for some reason using `get_dynamic_data` which is not implemented and returns empty dictionary.

## Testing notes:
1. USD workflow does work and is using entities set on the instance instead of context entities to get product name template.
2. FBX and HDA can be created and published.
