### PR TITLE
fix opmenu.xml: remove leftover "insertBefore" and add context-expression

### DIFF
--- a/client/ayon_houdini/startup/OPmenu.xml
+++ b/client/ayon_houdini/startup/OPmenu.xml
@@ -7,13 +7,13 @@
     <menu>
         <!-- Operator type and asset options. -->
 
-        <insertBefore>opmenu.unsynchronize</insertBefore>
-            <scriptItem id="opmenu.vhda_create_ayon">
-                <insertAfter>opmenu.vhda_create</insertAfter>
-                <label>Create Digital Asset (AYON)...</label>
-                <context>
-                </context>
-                <scriptCode>
+        <scriptItem id="opmenu.vhda_create_ayon">
+            <insertAfter>opmenu.vhda_create</insertAfter>
+            <label>Create Digital Asset (AYON)...</label>
+            <context>
+                <expression>kwargs["node"].canCreateDigitalAsset()</expression>
+            </context>
+            <scriptCode>
 <![CDATA[
 from ayon_houdini.api.creator_node_shelves import create_interactive
 
@@ -22,7 +22,7 @@ if node not in hou.selectedNodes():
     node.setSelected(True)
 create_interactive("io.openpype.creators.houdini.hda", **kwargs)
 ]]>
-                </scriptCode>
-            </scriptItem>
+            </scriptCode>
+        </scriptItem>
     </menu>
 </menuDocument>


### PR DESCRIPTION
## Changelog Description
cleanup a leftover `insertBefore` and add a `<context><expression>` to match houdini's stock behaviour

## Additional review information
The `<insertBefore>` tag was left in the root of the menu causing this error message to popup
```
Error while parsing a menu definition file
 '/home/v/.local/share/AYON/addons/houdini_0.9.3/ayon_houdini/startup/OPmenu.xml':
Cannot set order: element 'root_menu' has no parent.
Cannot set order: element 'root_menu' has no parent.
Cannot set order: element 'root_menu' has no parent.
Cannot set order: element 'root_menu' has no parent.
```

while at it I noticed the `<context>` tag was left empty. I copied in the same expression used in houdini's stock `OPmenu.xml` so we match that behaviour.
stock behaviour around line 1746 in `/path/to/your/houdini/install/houdini-20.5.550-linux_x86_64_gcc11.2/houdini/OPmenu.xml`
```xml
        <!-- Operator type and asset options. -->
        <scriptItem id="opmenu.vhda_create">
            <label>Create Digital Asset...</label>
            <context>
                        <expression>
return kwargs["node"].canCreateDigitalAsset()
                </expression>
            </context>
            <scriptCode><![CDATA[
import assettools
assettools.createAssetFromSubnet(kwargs["node"])
]]>
            </scriptCode>
        </scriptItem>
```

previously the menu entry was showing up all the time, even if the selected nodes could not be converted into a hda
<img width="361" height="498" alt="image" src="https://github.com/user-attachments/assets/0b14c7de-db42-46ab-aae7-be4d19bdda93" />

now, it should only show up when `canCreateDigitalAsset()` returns true.
<img width="311" height="487" alt="image" src="https://github.com/user-attachments/assets/77115f76-7155-47e2-9873-9568766689a3" />


## Testing notes:
1. right click on a node --> confirm error messages are showing up in the terminal
2. apply this patch --> confirm error messages are gone
