### PR TITLE
`ValidateExportParameterValue`: Exclude `karma_rop`

### DIFF
--- a/client/ayon_houdini/plugins/publish/validate_export.py
+++ b/client/ayon_houdini/plugins/publish/validate_export.py
@@ -29,7 +29,6 @@ class ValidateExportParameterValue(plugin.HoudiniInstancePlugin):
 
     order = pyblish.api.ValidatorOrder
     families = ["mantra_rop",
-                "karma_rop",
                 "redshift_rop",
                 "arnold_rop",
                 "vray_rop",


### PR DESCRIPTION
## Changelog Description
Exclude `karma_rop` from `ValidateExportParameterValue`

## Additional review information
`karma_rop` should be excluded because as it doesn't support the `"Farm Export & Farm Rendering"` and `"Local Export & Farm Rendering"`

## Testing notes:
1. Publishing render using Karma products should work.


Resolve #353