### PR TITLE
🏛️Product base types: product type settings for creators

### DIFF
--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -859,11 +859,18 @@ class SelectProductDialog(QtWidgets.QDialog):
 
         product_base_types = [product_base_type] if product_base_type else None
 
-        products = ayon_api.get_products(
-            self.project_name,
-            folder_ids=[self.folder_id],
-            product_base_types=product_base_types,
-        )
+        kwargs = {
+            "project_name": self.project_name,
+            "folder_ids": [self.folder_id],
+        }
+
+        if ayon_api.get_server_version_tuple() >= (1, 14, 0):
+            kwargs["product_base_types"] = product_base_types
+        else:
+            kwargs["product_types"] = product_base_types
+
+        products = ayon_api.get_products(**kwargs)
+
 
         return list(sorted(product["name"] for product in products))
 

--- a/client/ayon_houdini/api/hda_utils.py
+++ b/client/ayon_houdini/api/hda_utils.py
@@ -785,41 +785,41 @@ class SelectProductDialog(QtWidgets.QDialog):
         self.folder_id = folder_id
 
         # Create widgets and layout
-        product_types_widget = QtWidgets.QComboBox()
+        product_base_types_widget = QtWidgets.QComboBox()
         products_widget = QtWidgets.QListWidget()
         accept_button = QtWidgets.QPushButton("Set product name")
 
         main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.setContentsMargins(0, 0, 0, 0)
-        main_layout.addWidget(product_types_widget, 0)
+        main_layout.addWidget(product_base_types_widget, 0)
         main_layout.addWidget(products_widget, 1)
         main_layout.addWidget(accept_button, 0)
 
-        self.product_types_widget = product_types_widget
+        self.product_base_types_widget = product_base_types_widget
         self.products_widget = products_widget
 
         # Connect Signals
-        product_types_widget.currentTextChanged.connect(
-            self.on_product_type_changed
+        self.product_base_types_widget.currentTextChanged.connect(
+            self.on_product_base_type_changed
         )
         products_widget.itemDoubleClicked.connect(self.accept)
         accept_button.clicked.connect(self.accept)
 
         # Initialize widgets contents
-        product_types_widget.addItems(self.get_product_types())
-        product_type = self.get_selected_product_type()
-        self.set_product_type(product_type)
+        self.product_base_types_widget.addItems(self.get_product_base_types())
+        product_base_type = self.get_selected_product_base_type()
+        self.set_product_base_type(product_base_type)
 
     def get_selected_product(self) -> str:
         if self.products_widget.currentItem():
             return self.products_widget.currentItem().text()
         return ""
 
-    def get_selected_product_type(self) -> str:
-        return self.product_types_widget.currentText()
+    def get_selected_product_base_type(self) -> str:
+        return self.product_base_types_widget.currentText()
 
-    def get_product_types(self) -> List[str]:
-        """return default product types."""
+    def get_product_base_types(self) -> List[str]:
+        """return default product base types."""
 
         return [
             "*",
@@ -830,18 +830,18 @@ class SelectProductDialog(QtWidgets.QDialog):
             "usd",
         ]
 
-    def on_product_type_changed(self, product_type: str):
-        self.set_product_type(product_type)
+    def on_product_base_type_changed(self, product_base_type: str):
+        self.set_product_base_type(product_base_type)
 
-    def set_product_type(self, product_type: str):
-        self.product_types_widget.setCurrentText(product_type)
+    def set_product_base_type(self, product_base_type: str):
+        self.product_base_types_widget.setCurrentText(product_base_type)
 
-        if self.product_types_widget.currentText() != product_type:
+        if self.product_base_types_widget.currentText() != product_base_type:
             # Product type does not exist
             return
 
         # Populate products list
-        products = self.get_available_products(product_type)
+        products = self.get_available_products(product_base_type)
         self.products_widget.clear()
         if products:
             self.products_widget.addItems(products)
@@ -853,16 +853,16 @@ class SelectProductDialog(QtWidgets.QDialog):
         if matching_items:
             self.products_widget.setCurrentItem(matching_items[0])
 
-    def get_available_products(self, product_type):
-        if product_type == "*":
-            product_type = ""
+    def get_available_products(self, product_base_type):
+        if product_base_type == "*":
+            product_base_type = ""
 
-        product_types = [product_type] if product_type else None
+        product_base_types = [product_base_type] if product_base_type else None
 
         products = ayon_api.get_products(
             self.project_name,
             folder_ids=[self.folder_id],
-            product_types=product_types,
+            product_base_types=product_base_types,
         )
 
         return list(sorted(product["name"] for product in products))

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -414,6 +414,10 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
         for key, value in settings.items():
             setattr(self, key, value)
 
+        self.product_type_items = self._convert_product_type_items(
+            self.product_type_items
+        )
+
     def get_staging_dir(self, instance) -> Optional[StagingDir]:
         """Get Staging Dir
 

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -211,7 +211,6 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
             instance_data["families"] = self.get_publish_families()
             product_type = (
                 instance_data.get("productType")
-                or self.product_type
                 or self.product_base_type
             )
             instance = CreatedInstance(

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -209,8 +209,13 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
             instance_data["instance_node"] = instance_node.path()
             instance_data["instance_id"] = instance_node.path()
             instance_data["families"] = self.get_publish_families()
+            product_type = (
+                instance_data.get("productType")
+                or self.product_type
+                or self.product_base_type
+            )
             instance = CreatedInstance(
-                product_type=self.product_type,
+                product_type=product_type,
                 product_base_type=self.product_base_type,
                 product_name=product_name,
                 data=instance_data,

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -210,10 +210,11 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
             instance_data["instance_id"] = instance_node.path()
             instance_data["families"] = self.get_publish_families()
             instance = CreatedInstance(
-                self.product_type,
-                product_name,
-                instance_data,
-                self)
+                product_type=self.product_type,
+                product_base_type=self.product_base_type,
+                product_name=product_name,
+                data=instance_data,
+                creator=self)
 
             if self.enable_staging_path_management:
                 staging_dir_info = self.get_staging_dir(instance)
@@ -474,16 +475,6 @@ class RenderLegacyProductTypeCreator(HoudiniCreator):
     # because it inherits as property from `Creator`.
     product_base_type = "render"
     product_type = "render"
-    legacy_product_type = "render"
-    use_legacy_product_type = False
-
-    def apply_settings(self, project_settings):
-        super().apply_settings(project_settings)
-        use_legacy_product_type = project_settings["houdini"]["create"].get(
-            "render_rops_use_legacy_product_type", False
-        )
-        if use_legacy_product_type:
-            self.product_type = self.legacy_product_type
 
 
 class HoudiniLoader(load.LoaderPlugin):

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -177,7 +177,13 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
     settings_name = None
     add_publish_button = False
     default_staging_dir = "$HIP/ayon"
-    enable_staging_path_management = True
+selected_nodes = []
+settings_name = None
+add_publish_button = False
+default_staging_dir = "$HIP/ayon"    
+enable_staging_path_management = True
+skip_discovery = True
+
 
     settings_category = SETTINGS_CATEGORY
 

--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -177,12 +177,8 @@ class HoudiniCreator(Creator, HoudiniCreatorBase):
     settings_name = None
     add_publish_button = False
     default_staging_dir = "$HIP/ayon"
-selected_nodes = []
-settings_name = None
-add_publish_button = False
-default_staging_dir = "$HIP/ayon"    
-enable_staging_path_management = True
-skip_discovery = True
+    enable_staging_path_management = True
+    skip_discovery = True
 
 
     settings_category = SETTINGS_CATEGORY

--- a/client/ayon_houdini/plugins/create/create_alembic_camera.py
+++ b/client/ayon_houdini/plugins/create/create_alembic_camera.py
@@ -12,8 +12,8 @@ class CreateAlembicCamera(plugin.HoudiniCreator):
 
     identifier = "io.openpype.creators.houdini.camera"
     label = "Camera (Abc)"
-    product_type = "camera"
     product_base_type = "camera"
+    product_type = product_base_type
     icon = "camera"
     description = __doc__
 

--- a/client/ayon_houdini/plugins/create/create_arnold_ass.py
+++ b/client/ayon_houdini/plugins/create/create_arnold_ass.py
@@ -9,8 +9,8 @@ class CreateArnoldAss(plugin.HoudiniCreator):
 
     identifier = "io.openpype.creators.houdini.ass"
     label = "Arnold ASS"
-    product_type = "ass"
     product_base_type = "ass"
+    product_type = product_base_type
     icon = "magic"
     description = __doc__
 

--- a/client/ayon_houdini/plugins/create/create_arnold_rop.py
+++ b/client/ayon_houdini/plugins/create/create_arnold_rop.py
@@ -7,8 +7,8 @@ class CreateArnoldRop(plugin.RenderLegacyProductTypeCreator):
 
     identifier = "io.openpype.creators.houdini.arnold_rop"
     label = "Arnold ROP"
-    legacy_product_type = "arnold_rop"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     description =  "Create Arnold ROP for rendering with Arnold"
 

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -10,8 +10,9 @@ class CreateBGEO(plugin.HoudiniCreator):
     """BGEO pointcache creator."""
     identifier = "io.openpype.creators.houdini.bgeo"
     label = "PointCache (Bgeo)"
-    product_type = "pointcache"
     product_base_type = "pointcache"
+    product_type = product_base_type
+
     icon = "cubes"
     description = "Create Geometry ROP to export BGEO pointcache data"
 

--- a/client/ayon_houdini/plugins/create/create_composite.py
+++ b/client/ayon_houdini/plugins/create/create_composite.py
@@ -13,8 +13,9 @@ class CreateCompositeSequence(plugin.HoudiniCreator):
     identifier = "io.openpype.creators.houdini.imagesequence"
     label = "Composite (COP2)"
     description = "Render legacy COP2 ROP to image sequence"
-    product_type = "imagesequence"
     product_base_type = "imagesequence"
+    product_type = product_base_type
+
     icon = "fa5.eye"
 
     ext = ".exr"

--- a/client/ayon_houdini/plugins/create/create_copernicus.py
+++ b/client/ayon_houdini/plugins/create/create_copernicus.py
@@ -13,8 +13,8 @@ class CreateCopernicusROP(plugin.HoudiniCreator):
     identifier = "io.ayon.creators.houdini.copernicus"
     label = "Composite (Copernicus)"
     description = "Render using the Copernicus Image ROP"
-    product_type = "render"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "fa5.eye"
 
     ext = ".exr"

--- a/client/ayon_houdini/plugins/create/create_fbx.py
+++ b/client/ayon_houdini/plugins/create/create_fbx.py
@@ -11,8 +11,8 @@ class CreateFBX(plugin.HoudiniCreator):
 
     identifier = "io.ayon.creators.houdini.model.fbx"
     label = "Model (FBX)"
-    product_type = "model"
     product_base_type = "model"
+    product_type = product_base_type
     icon = "cube"
     default_variants = ["Main"]
     description = "Create a static model as FBX file"
@@ -171,8 +171,8 @@ class CreateStaticMesh(CreateFBX):
 
     identifier = "io.openpype.creators.houdini.staticmesh.fbx"
     label = "Static Mesh (FBX)"
-    product_type = "staticMesh"
     product_base_type = "staticMesh"
+    product_type = product_base_type
     icon = "cube"
     description = __doc__
 

--- a/client/ayon_houdini/plugins/create/create_hda.py
+++ b/client/ayon_houdini/plugins/create/create_hda.py
@@ -154,8 +154,8 @@ class CreateHDA(plugin.HoudiniCreator):
     identifier = "io.openpype.creators.houdini.hda"
     label = "Houdini Digital Asset (Hda)"
     description = "Create a Houdini Digital Asset (HDA) product"
-    product_type = "hda"
     product_base_type = "hda"
+    product_type = product_base_type
     icon = "gears"
 
     def _check_existing(self, folder_path, product_name):

--- a/client/ayon_houdini/plugins/create/create_karma_rop.py
+++ b/client/ayon_houdini/plugins/create/create_karma_rop.py
@@ -8,8 +8,8 @@ class CreateKarmaROP(plugin.RenderLegacyProductTypeCreator):
     """Karma ROP"""
     identifier = "io.openpype.creators.houdini.karma_rop"
     label = "Karma ROP"
-    legacy_product_type = "karma_rop"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     description = "Create Karma ROP for rendering with Karma"
 

--- a/client/ayon_houdini/plugins/create/create_mantra_rop.py
+++ b/client/ayon_houdini/plugins/create/create_mantra_rop.py
@@ -8,8 +8,8 @@ class CreateMantraROP(plugin.RenderLegacyProductTypeCreator):
     """Mantra ROP"""
     identifier = "io.openpype.creators.houdini.mantra_rop"
     label = "Mantra ROP"
-    legacy_product_type = "mantra_rop"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     description = "Create Mantra ROP for rendering with Mantra"
 

--- a/client/ayon_houdini/plugins/create/create_model.py
+++ b/client/ayon_houdini/plugins/create/create_model.py
@@ -21,8 +21,8 @@ class CreateModel(plugin.HoudiniCreator):
     """Create Model"""
     identifier = "io.openpype.creators.houdini.model"
     label = "Model (Abc)"
-    product_type = "model"
     product_base_type = "model"
+    product_type = product_base_type
     icon = "cube"
     description = "Create a static model as Alembic file"
 

--- a/client/ayon_houdini/plugins/create/create_pointcache.py
+++ b/client/ayon_houdini/plugins/create/create_pointcache.py
@@ -11,8 +11,8 @@ class CreatePointCache(plugin.HoudiniCreator):
     """Alembic ROP to pointcache"""
     identifier = "io.openpype.creators.houdini.pointcache"
     label = "PointCache (Abc)"
-    product_type = "pointcache"
     product_base_type = "pointcache"
+    product_type = product_base_type
     icon = "cubes"
     description = "Create Alembic ROP to export pointcache data"
 

--- a/client/ayon_houdini/plugins/create/create_pointcloud_prt.py
+++ b/client/ayon_houdini/plugins/create/create_pointcloud_prt.py
@@ -15,8 +15,8 @@ class CreatePRTPointCloud(plugin.HoudiniCreator):
     """
     identifier = "io.ayon.creators.houdini.pointcloud.prt"
     label = "PointCloud (PRT)"
-    product_type = "pointcloud"
     product_base_type = "pointcloud"
+    product_type = product_base_type
     icon = "cubes"
     description = "PRT pointcloud creator"
 

--- a/client/ayon_houdini/plugins/create/create_redshift_proxy.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_proxy.py
@@ -9,8 +9,9 @@ class CreateRedshiftProxy(plugin.HoudiniCreator):
     """Redshift Proxy"""
     identifier = "io.openpype.creators.houdini.redshiftproxy"
     label = "Redshift Proxy"
-    product_type = "redshiftproxy"
     product_base_type = "redshiftproxy"
+    product_type = product_base_type
+
     icon = "magic"
     description = "Export Redshift Proxy (.rs)"
 

--- a/client/ayon_houdini/plugins/create/create_redshift_rop.py
+++ b/client/ayon_houdini/plugins/create/create_redshift_rop.py
@@ -13,8 +13,8 @@ class CreateRedshiftROP(plugin.RenderLegacyProductTypeCreator):
     identifier = "io.openpype.creators.houdini.redshift_rop"
     label = "Redshift ROP"
     description = "Create Redshift ROP for rendering with Redshift"
-    legacy_product_type = "redshift_rop"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     ext = "exr"
     multi_layered_mode = "1"  # No Multi-Layered EXR File

--- a/client/ayon_houdini/plugins/create/create_review.py
+++ b/client/ayon_houdini/plugins/create/create_review.py
@@ -12,8 +12,8 @@ class CreateReview(plugin.HoudiniCreator):
 
     identifier = "io.openpype.creators.houdini.review"
     label = "Review"
-    product_type = "review"
     product_base_type = "review"
+    product_type = product_base_type
     description = __doc__
     icon = "video-camera"
     review_color_space = ""

--- a/client/ayon_houdini/plugins/create/create_rig.py
+++ b/client/ayon_houdini/plugins/create/create_rig.py
@@ -11,8 +11,8 @@ class CreateRig(plugin.HoudiniCreator):
     """APEX Rig (bgeo) creator."""
     identifier = "io.ayon.creators.houdini.bgeo.rig"
     label = "Rig"
-    product_type = "rig"
     product_base_type = "rig"
+    product_type = product_base_type
     icon = "wheelchair"
 
     description = "APEX rig exported as BGEO file"

--- a/client/ayon_houdini/plugins/create/create_usd.py
+++ b/client/ayon_houdini/plugins/create/create_usd.py
@@ -166,8 +166,8 @@ class CreateUSDLook(CreateUSD):
 
     identifier = "io.openpype.creators.houdini.usd.look"
     label = "USD Asset Look"
-    product_type = "look"
     product_base_type = "look"
+    product_type = product_base_type
     icon = "paint-brush"
     enabled = True
     description = "Create USD Asset Look with localized textures"

--- a/client/ayon_houdini/plugins/create/create_usd_componentbuilder.py
+++ b/client/ayon_houdini/plugins/create/create_usd_componentbuilder.py
@@ -9,8 +9,8 @@ import hou
 class CreateUSDComponentBuilder(plugin.HoudiniCreator):
     identifier = "io.ayon.creators.houdini.componentbuilder"
     label = "USD Component Builder LOPs"
-    product_type = "usd"
     product_base_type = "usd"
+    product_type = product_base_type
     icon = "cubes"
     description = "Create USD from Component Builder LOPs"
 

--- a/client/ayon_houdini/plugins/create/create_usdrender.py
+++ b/client/ayon_houdini/plugins/create/create_usdrender.py
@@ -25,8 +25,8 @@ class CreateUSDRender(plugin.RenderLegacyProductTypeCreator):
     """USD Render ROP in /stage"""
     identifier = "io.openpype.creators.houdini.usdrender"
     label = "USD Render"
-    legacy_product_type = "usdrender"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     description = "Create USD Render"
 

--- a/client/ayon_houdini/plugins/create/create_vbd_cache.py
+++ b/client/ayon_houdini/plugins/create/create_vbd_cache.py
@@ -12,8 +12,8 @@ class CreateVDBCache(plugin.HoudiniCreator):
     name = "vbdcache"
     label = "VDB Cache"
     description = __doc__
-    product_type = "vdbcache"
     product_base_type = "vdbcache"
+    product_type = product_base_type
     icon = "cloud"
 
     # Default render target

--- a/client/ayon_houdini/plugins/create/create_vray_rop.py
+++ b/client/ayon_houdini/plugins/create/create_vray_rop.py
@@ -13,8 +13,8 @@ class CreateVrayROP(plugin.RenderLegacyProductTypeCreator):
     identifier = "io.openpype.creators.houdini.vray_rop"
     label = "VRay ROP"
     description = "Create V-Ray ROP for rendering with V-Ray"
-    legacy_product_type = "vray_rop"
     product_base_type = "render"
+    product_type = product_base_type
     icon = "magic"
     ext = "exr"
 

--- a/client/ayon_houdini/plugins/create/create_workfile.py
+++ b/client/ayon_houdini/plugins/create/create_workfile.py
@@ -10,8 +10,8 @@ class CreateWorkfile(plugin.HoudiniCreatorBase, AutoCreator):
     settings_category = "houdini"
     identifier = "io.openpype.creators.houdini.workfile"
     label = "Workfile"
-    product_type = "workfile"
     product_base_type = "workfile"
+    product_type = product_base_type
     icon = "fa5.file"
 
     default_variant = "Main"

--- a/client/ayon_houdini/plugins/load/actions.py
+++ b/client/ayon_houdini/plugins/load/actions.py
@@ -8,13 +8,14 @@ from ayon_houdini.api import plugin
 class SetFrameRangeLoader(plugin.HoudiniLoader):
     """Set frame range excluding pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "pointcache",
         "vdbcache",
         "usd",
     }
+    product_types = product_base_types
     representations = {"abc", "vdb", "usd"}
 
     label = "Set frame range"
@@ -45,13 +46,14 @@ class SetFrameRangeLoader(plugin.HoudiniLoader):
 class SetFrameRangeWithHandlesLoader(plugin.HoudiniLoader):
     """Set frame range including pre- and post-handles"""
 
-    product_types = {
+    product_base_types = {
         "animation",
         "camera",
         "pointcache",
         "vdbcache",
         "usd",
     }
+    product_types = product_base_types
     representations = {"abc", "vdb", "usd"}
 
     label = "Set frame range (with handles)"

--- a/client/ayon_houdini/plugins/load/load_alembic.py
+++ b/client/ayon_houdini/plugins/load/load_alembic.py
@@ -12,7 +12,8 @@ from ayon_houdini.api import (
 class AbcLoader(plugin.HoudiniLoader):
     """Load Alembic"""
 
-    product_types = {"model", "animation", "pointcache", "gpuCache"}
+    product_base_types = {"model", "animation", "pointcache", "gpuCache"}
+    product_types = product_base_types
     label = "Load Alembic"
     representations = {"*"}
     extensions = {"abc"}

--- a/client/ayon_houdini/plugins/load/load_alembic_archive.py
+++ b/client/ayon_houdini/plugins/load/load_alembic_archive.py
@@ -12,7 +12,8 @@ from ayon_houdini.api import (
 class AbcArchiveLoader(plugin.HoudiniLoader):
     """Load Alembic as full geometry network hierarchy """
 
-    product_types = {"model", "animation", "pointcache", "gpuCache"}
+    product_base_types = {"model", "animation", "pointcache", "gpuCache"}
+    product_types = product_base_types
     label = "Load Alembic as Archive"
     representations = {"*"}
     extensions = {"abc"}

--- a/client/ayon_houdini/plugins/load/load_ass.py
+++ b/client/ayon_houdini/plugins/load/load_ass.py
@@ -10,7 +10,8 @@ from ayon_houdini.api import (
 class AssLoader(plugin.HoudiniLoader):
     """Load .ass with Arnold Procedural"""
 
-    product_types = {"ass"}
+    product_base_types = {"ass"}
+    product_types = product_base_types
     label = "Load Arnold Procedural"
     representations = {"ass"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_asset_lop.py
+++ b/client/ayon_houdini/plugins/load/load_asset_lop.py
@@ -8,7 +8,8 @@ import hou
 class LOPLoadAssetLoader(load.LoaderPlugin):
     """Load reference/payload into Solaris using AYON `lop_import` LOP"""
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     label = "Load Asset (LOPs)"
     representations = ["usd", "abc", "usda", "usdc"]
     order = -10

--- a/client/ayon_houdini/plugins/load/load_bgeo.py
+++ b/client/ayon_houdini/plugins/load/load_bgeo.py
@@ -12,7 +12,8 @@ class BgeoLoader(plugin.HoudiniLoader):
     """Load bgeo files to Houdini."""
 
     label = "Load bgeo"
-    product_types = {"model", "pointcache", "bgeo"}
+    product_base_types = {"model", "pointcache", "bgeo"}
+    product_types = product_base_types
     representations = {
         "bgeo", "bgeosc", "bgeogz",
         "bgeo.sc", "bgeo.gz", "bgeo.lzma", "bgeo.bz2"}

--- a/client/ayon_houdini/plugins/load/load_camera.py
+++ b/client/ayon_houdini/plugins/load/load_camera.py
@@ -91,7 +91,9 @@ def transfer_non_default_values(src, dest, ignore=None):
 class CameraLoader(plugin.HoudiniLoader):
     """Load camera from an Alembic file"""
 
-    product_types = {"camera"}
+    product_base_types = {"camera"}
+    product_types = product_base_types
+
     label = "Load Camera (abc)"
     representations = {"abc"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_fbx.py
+++ b/client/ayon_houdini/plugins/load/load_fbx.py
@@ -18,7 +18,8 @@ class FbxLoader(plugin.HoudiniLoader):
 
     order = -10
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations = {"*"}
     extensions = {"fbx"}
 

--- a/client/ayon_houdini/plugins/load/load_filepath.py
+++ b/client/ayon_houdini/plugins/load/load_filepath.py
@@ -21,7 +21,8 @@ class FilePathLoader(plugin.HoudiniLoader):
     order = 9
     icon = "link"
     color = "white"
-    product_types = {"*"}
+    product_base_type = {"*"}
+    product_types = product_base_type
     representations = {"*"}
 
     def load(self, context, name=None, namespace=None, data=None):

--- a/client/ayon_houdini/plugins/load/load_hda.py
+++ b/client/ayon_houdini/plugins/load/load_hda.py
@@ -16,7 +16,8 @@ from ayon_houdini.api import (
 class HdaLoader(plugin.HoudiniLoader):
     """Load Houdini Digital Asset file."""
 
-    product_types = {"hda"}
+    product_base_types = {"hda"}
+    product_types = product_base_types
     label = "Load Hda"
     representations = {"hda"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_image.py
+++ b/client/ayon_houdini/plugins/load/load_image.py
@@ -29,7 +29,7 @@ def get_image_ayon_container():
 class ImageLoader(plugin.HoudiniLoader):
     """Load images into COP2"""
 
-    product_types = {
+    product_base_types = {
         "imagesequence",
         "review",
         "render",
@@ -37,6 +37,7 @@ class ImageLoader(plugin.HoudiniLoader):
         "image",
         "online",
     }
+    product_types = product_base_types
     label = "Load Image (COP2)"
     representations = {"*"}
     order = -9

--- a/client/ayon_houdini/plugins/load/load_image_copernicus.py
+++ b/client/ayon_houdini/plugins/load/load_image_copernicus.py
@@ -36,7 +36,7 @@ class ImageCopernicusLoader(plugin.HoudiniLoader):
     "Object Merge" COP node, so we cannot merge nodes from another Cop network.
     """
 
-    product_types = {
+    product_base_types = {
         "imagesequence",
         "review",
         "render",
@@ -44,6 +44,7 @@ class ImageCopernicusLoader(plugin.HoudiniLoader):
         "image",
         "online",
     }
+    product_types = product_base_types
     label = "Load Image (Copernicus)"
     representations = {"*"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_houdini/plugins/load/load_redshift_proxy.py
@@ -12,7 +12,8 @@ from ayon_houdini.api import (
 class RedshiftProxyLoader(plugin.HoudiniLoader):
     """Load Redshift Proxy"""
 
-    product_types = {"redshiftproxy"}
+    product_base_types = {"redshiftproxy"}
+    product_types = product_base_types
     label = "Load Redshift Proxy"
     representations = {"rs"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_shot_lop.py
+++ b/client/ayon_houdini/plugins/load/load_shot_lop.py
@@ -8,7 +8,8 @@ import hou
 class LOPLoadShotLoader(load.LoaderPlugin):
     """Load sublayer into Solaris using AYON Load Shot LOP"""
 
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     label = "Load Shot (LOPs)"
     representations = ["usd", "abc", "usda", "usdc"]
     order = -10

--- a/client/ayon_houdini/plugins/load/load_usd_layer.py
+++ b/client/ayon_houdini/plugins/load/load_usd_layer.py
@@ -12,10 +12,11 @@ from ayon_houdini.api import (
 class USDSublayerLoader(plugin.HoudiniLoader):
     """Sublayer USD file in Solaris"""
 
-    product_types = {
+    product_base_types = {
         "usd",
         "usdCamera",
     }
+    product_types = product_base_types
     label = "Sublayer USD"
     representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = 1

--- a/client/ayon_houdini/plugins/load/load_usd_reference.py
+++ b/client/ayon_houdini/plugins/load/load_usd_reference.py
@@ -12,10 +12,11 @@ from ayon_houdini.api import (
 class USDReferenceLoader(plugin.HoudiniLoader):
     """Reference USD file in Solaris"""
 
-    product_types = {
+    product_base_types = {
         "usd",
         "usdCamera",
     }
+    product_types = product_base_types
     label = "Reference USD"
     representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = -8

--- a/client/ayon_houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_houdini/plugins/load/load_usd_sop.py
@@ -11,7 +11,8 @@ class SopUsdImportLoader(plugin.HoudiniLoader):
     """Load USD to SOPs via `usdimport`"""
 
     label = "Load USD to SOPs"
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     representations = {"usd"}
     order = -6
     icon = "code-fork"

--- a/client/ayon_houdini/plugins/load/load_vdb.py
+++ b/client/ayon_houdini/plugins/load/load_vdb.py
@@ -10,7 +10,8 @@ from ayon_houdini.api import (
 class VdbLoader(plugin.HoudiniLoader):
     """Load VDB"""
 
-    product_types = {"vdbcache"}
+    product_base_types = {"vdbcache"}
+    product_types = product_base_types
     label = "Load VDB"
     representations = {"vdb"}
     order = -10

--- a/client/ayon_houdini/plugins/load/show_usdview.py
+++ b/client/ayon_houdini/plugins/load/show_usdview.py
@@ -12,7 +12,8 @@ class ShowInUsdview(plugin.HoudiniLoader):
 
     label = "Show in usdview"
     representations = {"*"}
-    product_types = {"*"}
+    product_base_types = {"*"}
+    product_types = product_base_types
     extensions = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = 15
 

--- a/client/ayon_houdini/plugins/publish/collect_frames_fix.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames_fix.py
@@ -68,13 +68,14 @@ class CollectFramesFixDefHou(
             )
             return
 
-        product_type = product_entity["productType"]
-        instance_product_type = instance.data["productType"]
-        if product_type != instance_product_type:
+        product_base_type = product_entity["productBaseType"]
+        instance_product_base_type = instance.data["productBaseType"]
+        if product_base_type != instance_product_base_type:
             self.log.error(
-                f"Existing product '{product_name}' product type "
-                f"'{product_type}' is not the same as instance product type "
-                f"'{instance_product_type}'. Re-render may have unintended "
+                f"Existing product '{product_name}' product base type "
+                f"'{product_base_type}' is not the same as instance "
+                "product base type "
+                f"'{instance_product_base_type}'. Re-render may have unintended "
                 f"side effects.")
 
         version_entity = ayon_api.get_last_version_by_product_id(

--- a/client/ayon_houdini/plugins/publish/collect_frames_fix.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames_fix.py
@@ -68,15 +68,18 @@ class CollectFramesFixDefHou(
             )
             return
 
-        product_base_type = product_entity["productBaseType"]
+        product_base_type = (
+                product_entity["productBaseType"]
+                or product_entity["productType"]
+        )
         instance_product_base_type = instance.data["productBaseType"]
         if product_base_type != instance_product_base_type:
             self.log.error(
                 f"Existing product '{product_name}' product base type "
                 f"'{product_base_type}' is not the same as instance "
                 "product base type "
-                f"'{instance_product_base_type}'. Re-render may have unintended "
-                f"side effects.")
+                f"'{instance_product_base_type}'. Re-render may have "
+                "unintended side effects.")
 
         version_entity = ayon_api.get_last_version_by_product_id(
             project_name,

--- a/client/ayon_houdini/plugins/publish/collect_output_node.py
+++ b/client/ayon_houdini/plugins/publish/collect_output_node.py
@@ -67,7 +67,7 @@ class CollectOutputSOPPath(plugin.HoudiniInstancePlugin):
         else:
             raise KnownPublishError(
                 f"ROP node type '{node_type}' is not supported"
-                f" for product type '{instance.data['product_type']}'"
+                f" for product base type '{instance.data['productBaseType']}'"
             )
 
         if not out_node:

--- a/client/ayon_houdini/plugins/publish/collect_task_handles.py
+++ b/client/ayon_houdini/plugins/publish/collect_task_handles.py
@@ -131,7 +131,7 @@ class CollectAssetHandles(plugin.HoudiniInstancePlugin,
         if not cls.instance_matches_plugin_families(instance):
             return []
 
-        if instance.data.get("productBaseType") in cls.ignore_product_base_types:
+        if instance.data["productBaseType"] in cls.ignore_product_base_types:
             return []
 
         return [

--- a/client/ayon_houdini/plugins/publish/collect_task_handles.py
+++ b/client/ayon_houdini/plugins/publish/collect_task_handles.py
@@ -35,13 +35,14 @@ class CollectAssetHandles(plugin.HoudiniInstancePlugin,
     label = "Collect Task Handles"
     use_asset_handles = True
 
-    ignore_product_types: set[str] = {"rig"}
+    ignore_product_base_types: set[str] = {"rig"}
 
     def process(self, instance):
 
         # Do no check asset handles for products that are essentially not
         # intended to be time-based
-        if instance.data.get("productType") in self.ignore_product_types:
+        if instance.data.get(
+                "productBaseType") in self.ignore_product_base_types:
             return
 
         # Only process instances without already existing handles data
@@ -130,7 +131,7 @@ class CollectAssetHandles(plugin.HoudiniInstancePlugin,
         if not cls.instance_matches_plugin_families(instance):
             return []
 
-        if instance.data.get("productType") in cls.ignore_product_types:
+        if instance.data.get("productBaseType") in cls.ignore_product_base_types:
             return []
 
         return [

--- a/client/ayon_houdini/plugins/publish/collect_task_handles.py
+++ b/client/ayon_houdini/plugins/publish/collect_task_handles.py
@@ -41,8 +41,7 @@ class CollectAssetHandles(plugin.HoudiniInstancePlugin,
 
         # Do no check asset handles for products that are essentially not
         # intended to be time-based
-        if instance.data.get(
-                "productBaseType") in self.ignore_product_base_types:
+        if instance.data["productBaseType"] in self.ignore_product_base_types:
             return
 
         # Only process instances without already existing handles data

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -41,7 +41,7 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
 
         # In some cases representation name is not the the extension
         # TODO: Preferably we remove this very specific naming
-        product_base_type = instance.data["productBseType"]
+        product_base_type = instance.data["productBaseType"]
         name = {
             "bgeo": "bgeo",
             "rs": "rs",

--- a/client/ayon_houdini/plugins/publish/extract_rop.py
+++ b/client/ayon_houdini/plugins/publish/extract_rop.py
@@ -41,12 +41,12 @@ class ExtractROP(plugin.HoudiniExtractorPlugin):
 
         # In some cases representation name is not the the extension
         # TODO: Preferably we remove this very specific naming
-        product_type = instance.data["productType"]
+        product_base_type = instance.data["productBseType"]
         name = {
             "bgeo": "bgeo",
             "rs": "rs",
             "ass": "ass"
-        }.get(product_type, ext)
+        }.get(product_base_type, ext)
 
         representation = {
             "name": name,

--- a/client/ayon_houdini/plugins/publish/validate_file_extension.py
+++ b/client/ayon_houdini/plugins/publish/validate_file_extension.py
@@ -22,7 +22,7 @@ class ValidateFileExtension(plugin.HoudiniInstancePlugin):
     families = ["camera", "vdbcache"]
     label = "Output File Extension"
 
-    product_type_extensions = {
+    product_base_type_extensions = {
         "camera": ".abc",
         "vdbcache": ".vdb",
     }
@@ -39,11 +39,11 @@ class ValidateFileExtension(plugin.HoudiniInstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
         # Get expected extension
-        product_type = instance.data.get("productType")
-        extension = cls.product_type_extensions.get(product_type, None)
+        product_base_type = instance.data.get("productBaseType")
+        extension = cls.product_base_type_extensions.get(product_base_type, None)
         if extension is None:
             raise PublishValidationError(
-                "Unsupported product type: {}".format(product_type),
+                "Unsupported product base type: {}".format(product_base_type),
                 title=cls.label)
 
         # Perform extension check

--- a/client/ayon_houdini/plugins/publish/validate_file_extension.py
+++ b/client/ayon_houdini/plugins/publish/validate_file_extension.py
@@ -39,8 +39,8 @@ class ValidateFileExtension(plugin.HoudiniInstancePlugin):
     @classmethod
     def get_invalid(cls, instance):
         # Get expected extension
-        product_base_type = instance.data.get("productBaseType")
-        extension = cls.product_base_type_extensions.get(product_base_type, None)
+        product_base_type = instance.data["productBaseType"]
+        extension = cls.product_base_type_extensions.get(product_base_type)
         if extension is None:
             raise PublishValidationError(
                 "Unsupported product base type: {}".format(product_base_type),

--- a/client/ayon_houdini/plugins/publish/validate_houdini_license_category.py
+++ b/client/ayon_houdini/plugins/publish/validate_houdini_license_category.py
@@ -30,7 +30,7 @@ class ValidateHoudiniNotApprenticeLicense(plugin.HoudiniInstancePlugin):
 
         if hou.isApprentice():
             # Find which family or product type was matched with the plug-in
-            families = {instance.data["productType"]}
+            families = {instance.data["productBaseType"]}
             families.update(instance.data.get("families", []))
             disallowed_families = families.intersection(self.families)
             families = " ".join(sorted(disallowed_families)).title()

--- a/client/ayon_houdini/plugins/workfile_build/create_placeholder.py
+++ b/client/ayon_houdini/plugins/workfile_build/create_placeholder.py
@@ -36,10 +36,10 @@ class HoudiniPlaceholderCreatePlugin(
     def get_placeholder_node_name(self, placeholder_data):
         create_context = CreateContext(registered_host())
         creator = create_context.creators.get(placeholder_data["creator"])
-        product_type = creator.product_type
+        product_base_type = creator.product_base_type
         node_name = "{}_{}".format(
             self.identifier.replace(".", "_"),
-            product_type
+            product_base_type
         )
 
         return node_name

--- a/package.py
+++ b/package.py
@@ -10,5 +10,5 @@ ayon_required_addons = {
     "core": ">=1.8.0",
 }
 ayon_compatible_addons = {
-    "deadline": ">=0.5.20",
+    "deadline": ">=0.7.0",
 }

--- a/package.py
+++ b/package.py
@@ -7,7 +7,7 @@ project_can_override_addon_version = True
 
 ayon_server_version = ">=1.1.2"
 ayon_required_addons = {
-    "core": ">=1.6.11",
+    "core": ">=1.8.0",
 }
 ayon_compatible_addons = {
     "deadline": ">=0.5.20",

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -8,6 +8,7 @@ class ProductTypeItemModel(BaseSettingsModel):
         decription="Product type name"
     )
     label: str = SettingsField(
+        "",
         title="Label",
         description="Label to display in UI for the product type",
     )

--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -1,6 +1,18 @@
 from ayon_server.settings import BaseSettingsModel, SettingsField
 
 
+class ProductTypeItemModel(BaseSettingsModel):
+    _layout = "compact"
+    product_type: str = SettingsField(
+        title="Product Type",
+        decription="Product type name"
+    )
+    label: str = SettingsField(
+        title="Label",
+        description="Label to display in UI for the product type",
+    )
+
+
 # Creator Plugins
 class CreatorModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
@@ -8,6 +20,14 @@ class CreatorModel(BaseSettingsModel):
         title="Default Products",
         default_factory=list,
     )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types taht this plugin can create."
+        )
+    )
+
 
 def review_node_types_enum():
     return [
@@ -18,8 +38,15 @@ def review_node_types_enum():
 class CreateReviewModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     default_variants: list[str] = SettingsField(
-        title="Default Products",
+        title="Default Product Variants",
         default_factory=list,
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types taht this plugin can create."
+        )
     )
     node_type: str = SettingsField(
         title="Default Node Type",
@@ -29,8 +56,15 @@ class CreateReviewModel(BaseSettingsModel):
 class CreateArnoldAssModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     default_variants: list[str] = SettingsField(
-        title="Default Products",
+        title="Default Product Variants",
         default_factory=list,
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types taht this plugin can create."
+        )
     )
     ext: str = SettingsField(title="Extension")
     show_in_viewport_menu: bool = SettingsField(
@@ -48,7 +82,14 @@ class CreateStaticMeshModel(BaseSettingsModel):
     enabled: bool = SettingsField(title="Enabled")
     default_variants: list[str] = SettingsField(
         default_factory=list,
-        title="Default Products"
+        title="Default Product Variants",
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types taht this plugin can create."
+        )
     )
     static_mesh_prefix: str = SettingsField("S", title="Static Mesh Prefix")
     collision_prefixes: list[str] = SettingsField(
@@ -92,6 +133,13 @@ class WorkfileModel(BaseSettingsModel):
         description=(
             "Workfile cannot be disabled by user in UI."
             " Requires core addon 1.4.1 or newer."
+        )
+    )
+    product_type_items: list[ProductTypeItemModel] = SettingsField(
+        default_factory=list,
+        title="Product Type Items",
+        description=(
+            "Optional list of product types taht this plugin can create."
         )
     )
 


### PR DESCRIPTION
## Changelog Description
Changing the usage of `product_type` to `product_base_type` and adding support to customize product type in creator settings.

## Testing notes:

> [!WARNING]
> You'll need **ynput/ayon-core** 1.8 and higher

* Publishing and loading should work as before
* When you define new product type int the settings, you should be able to see new items in the publisher.
* Product name should work ok, you should be able to see changes if/when appropriate token is used in the template
* Publishing of instances created with new product type and loading them should work

Closes #359 