### PR TITLE
Render: Fix product name source

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_local_render_instances.py
@@ -227,7 +227,7 @@ class CollectLocalRenderInstances(plugin.HoudiniInstancePlugin,
         if use_legacy_product_name:
             return _get_legacy_product_name_and_group(
                 product_base_type,
-                dynamic_data.get("productName"),
+                instance.data["productName"],
                 instance.context.data["taskEntity"]["name"],
                 dynamic_data
             )


### PR DESCRIPTION
## Changelog Description
Pass source of product name value for `_get_legacy_product_name_and_group`.

## Additional review information
Fix issue created by https://github.com/ynput/ayon-houdini/pull/357 .

## Testing notes:
1. Local rendering should be working.

Resolves https://github.com/ynput/ayon-core/issues/1734