### PR TITLE
minor tweak to allow for loading _$F or .$F

### DIFF
--- a/client/ayon_houdini/api/plugin.py
+++ b/client/ayon_houdini/api/plugin.py
@@ -561,8 +561,8 @@ class HoudiniLoader(load.LoaderPlugin):
 
         # Assume the frame number is always the last digit
         pattern = re.compile(r"""
-            (.*)                # Everything before the last frame separator (greedy)
-            ([._])              # The literal dot or underscore before the frame number
+            (.*)                 # All before last frame separator (greedy)
+            ([._])               # Literal dot / underscore before frame number
             (\d+)                # the frame number
             (\.[^.]+(?:\..+)*)$  # extension (one or more dot segments)
         """, re.VERBOSE)


### PR DESCRIPTION
## Changelog Description
Just a minor tweak to the replace_with_frame_token function. So it captures the separator, whether it is . or _
