### PR TITLE
Loaders: Filters by extension instead of representation name

### DIFF
--- a/client/ayon_houdini/plugins/load/actions.py
+++ b/client/ayon_houdini/plugins/load/actions.py
@@ -16,7 +16,7 @@ class SetFrameRangeLoader(plugin.HoudiniLoader):
         "usd",
     }
     representations = {"*"}
-    extensions = {"abc", "vdb", "usd"}
+    extensions = {"abc", "vdb", "usd", "usda", "usdc", "usdlc", "usdnc"}
 
     label = "Set frame range"
     order = 11
@@ -54,7 +54,7 @@ class SetFrameRangeWithHandlesLoader(plugin.HoudiniLoader):
         "usd",
     }
     representations = {"*"}
-    extensions = {"abc", "vdb", "usd", "usda", "usdc"}
+    extensions = {"abc", "vdb", "usd", "usda", "usdc", "usdlc", "usdnc"}
 
     label = "Set frame range (with handles)"
     order = 12

--- a/client/ayon_houdini/plugins/load/actions.py
+++ b/client/ayon_houdini/plugins/load/actions.py
@@ -15,7 +15,8 @@ class SetFrameRangeLoader(plugin.HoudiniLoader):
         "vdbcache",
         "usd",
     }
-    representations = {"abc", "vdb", "usd"}
+    representations = {"*"}
+    extensions = {"abc", "vdb", "usd"}
 
     label = "Set frame range"
     order = 11

--- a/client/ayon_houdini/plugins/load/actions.py
+++ b/client/ayon_houdini/plugins/load/actions.py
@@ -53,7 +53,8 @@ class SetFrameRangeWithHandlesLoader(plugin.HoudiniLoader):
         "vdbcache",
         "usd",
     }
-    representations = {"abc", "vdb", "usd"}
+    representations = {"*"}
+    extensions = {"abc", "vdb", "usd", "usda", "usdc"}
 
     label = "Set frame range (with handles)"
     order = 12

--- a/client/ayon_houdini/plugins/load/load_ass.py
+++ b/client/ayon_houdini/plugins/load/load_ass.py
@@ -12,7 +12,8 @@ class AssLoader(plugin.HoudiniLoader):
 
     product_types = {"ass"}
     label = "Load Arnold Procedural"
-    representations = {"ass"}
+    representations = {"*"}
+    extensions = {"ass"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_asset_lop.py
+++ b/client/ayon_houdini/plugins/load/load_asset_lop.py
@@ -10,7 +10,8 @@ class LOPLoadAssetLoader(load.LoaderPlugin):
 
     product_types = {"*"}
     label = "Load Asset (LOPs)"
-    representations = ["usd", "abc", "usda", "usdc"]
+    representations = {"*"}
+    extensions = ["usd", "abc", "usda", "usdc"]
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_asset_lop.py
+++ b/client/ayon_houdini/plugins/load/load_asset_lop.py
@@ -11,7 +11,7 @@ class LOPLoadAssetLoader(load.LoaderPlugin):
     product_types = {"*"}
     label = "Load Asset (LOPs)"
     representations = {"*"}
-    extensions = ["usd", "abc", "usda", "usdc"]
+    extensions = {"usd", "usda", "usdc", "usdlc", "usdnc", "abc"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_bgeo.py
+++ b/client/ayon_houdini/plugins/load/load_bgeo.py
@@ -13,7 +13,8 @@ class BgeoLoader(plugin.HoudiniLoader):
 
     label = "Load bgeo"
     product_types = {"model", "pointcache", "bgeo"}
-    representations = {
+    representations = {"*"}
+    extensions = {
         "bgeo", "bgeosc", "bgeogz",
         "bgeo.sc", "bgeo.gz", "bgeo.lzma", "bgeo.bz2"}
     order = -10

--- a/client/ayon_houdini/plugins/load/load_camera.py
+++ b/client/ayon_houdini/plugins/load/load_camera.py
@@ -93,7 +93,8 @@ class CameraLoader(plugin.HoudiniLoader):
 
     product_types = {"camera"}
     label = "Load Camera (abc)"
-    representations = {"abc"}
+    representations = {"*"}
+    extensions = {"abc"}
     order = -10
 
     icon = "code-fork"

--- a/client/ayon_houdini/plugins/load/load_hda.py
+++ b/client/ayon_houdini/plugins/load/load_hda.py
@@ -18,7 +18,8 @@ class HdaLoader(plugin.HoudiniLoader):
 
     product_types = {"hda"}
     label = "Load Hda"
-    representations = {"hda"}
+    representations = {"*"}
+    extensions = {"hda"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_redshift_proxy.py
+++ b/client/ayon_houdini/plugins/load/load_redshift_proxy.py
@@ -14,7 +14,8 @@ class RedshiftProxyLoader(plugin.HoudiniLoader):
 
     product_types = {"redshiftproxy"}
     label = "Load Redshift Proxy"
-    representations = {"rs"}
+    representations = {"*"}
+    extensions = {"rs"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_shot_lop.py
+++ b/client/ayon_houdini/plugins/load/load_shot_lop.py
@@ -11,7 +11,7 @@ class LOPLoadShotLoader(load.LoaderPlugin):
     product_types = {"*"}
     label = "Load Shot (LOPs)"
     representations = {"*"}
-    extensions = ["usd", "abc", "usda", "usdc"]
+    extensions = {"usd", "usda", "usdc", "usdlc", "usdnc", "abc"}
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_shot_lop.py
+++ b/client/ayon_houdini/plugins/load/load_shot_lop.py
@@ -10,7 +10,8 @@ class LOPLoadShotLoader(load.LoaderPlugin):
 
     product_types = {"*"}
     label = "Load Shot (LOPs)"
-    representations = ["usd", "abc", "usda", "usdc"]
+    representations = {"*"}
+    extensions = ["usd", "abc", "usda", "usdc"]
     order = -10
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_usd_layer.py
+++ b/client/ayon_houdini/plugins/load/load_usd_layer.py
@@ -17,7 +17,8 @@ class USDSublayerLoader(plugin.HoudiniLoader):
         "usdCamera",
     }
     label = "Sublayer USD"
-    representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
+    representations = {"*"}
+    extensions = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = 1
 
     icon = "code-fork"

--- a/client/ayon_houdini/plugins/load/load_usd_reference.py
+++ b/client/ayon_houdini/plugins/load/load_usd_reference.py
@@ -17,7 +17,8 @@ class USDReferenceLoader(plugin.HoudiniLoader):
         "usdCamera",
     }
     label = "Reference USD"
-    representations = {"usd", "usda", "usdlc", "usdnc", "abc"}
+    representations = {"*"}
+    extensions = {"usd", "usda", "usdlc", "usdnc", "abc"}
     order = -8
 
     icon = "code-fork"

--- a/client/ayon_houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_houdini/plugins/load/load_usd_sop.py
@@ -13,7 +13,7 @@ class SopUsdImportLoader(plugin.HoudiniLoader):
     label = "Load USD to SOPs"
     product_types = {"*"}
     representations = {"*"}
-    extensions = {"usd"}
+    extensions = {"usd", "usda", "usdc", "usdlc", "usdnc"}
     order = -6
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_usd_sop.py
+++ b/client/ayon_houdini/plugins/load/load_usd_sop.py
@@ -12,7 +12,8 @@ class SopUsdImportLoader(plugin.HoudiniLoader):
 
     label = "Load USD to SOPs"
     product_types = {"*"}
-    representations = {"usd"}
+    representations = {"*"}
+    extensions = {"usd"}
     order = -6
     icon = "code-fork"
     color = "orange"

--- a/client/ayon_houdini/plugins/load/load_vdb.py
+++ b/client/ayon_houdini/plugins/load/load_vdb.py
@@ -12,7 +12,8 @@ class VdbLoader(plugin.HoudiniLoader):
 
     product_types = {"vdbcache"}
     label = "Load VDB"
-    representations = {"vdb"}
+    representations = {"*"}
+    extensions = {"vdb"}
     order = -10
     icon = "code-fork"
     color = "orange"


### PR DESCRIPTION
## Changelog Description

Loaders: Filters by extension instead of representation name

## Additional review information

Make loaders filter by extension instead of representation name so they are less restrictive on what can be loaded.

## Testing notes:

1. Validate code changes
2. Loaders should still be able to load the right representations, etc.