### PR TITLE
Publish apex animation

### DIFF
--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -151,3 +151,27 @@ class CreateRig(CreateBGEO):
 
     def set_trange(self, node):
         pass
+
+
+class CreateAnim(CreateBGEO):
+    """APEX Animation (bgeo) creator."""
+    identifier = "io.ayon.creators.houdini.bgeo.anim"
+    label = "APEX Animation"
+    product_type = "animation"
+    product_base_type = "animation"
+    icon = "male"
+
+    description = "APEX Animation data exported as BGEO file"
+
+    # Default render target
+    render_target = "local"
+
+    def get_detail_description(self):
+        return inspect.cleandoc(
+            """Write a BGEO output file as `animation` product type. This can
+             be used to publish APEX animations which are in essence just
+             SOP-level data representing APEX animation data."""
+        )
+
+    def get_publish_families(self):
+        return ["anim", "apex", "bgeo", "publish.hou"]

--- a/client/ayon_houdini/plugins/create/create_bgeo.py
+++ b/client/ayon_houdini/plugins/create/create_bgeo.py
@@ -158,8 +158,8 @@ class CreateAnim(CreateBGEO):
     """APEX Animation (bgeo) creator."""
     identifier = "io.ayon.creators.houdini.bgeo.anim"
     label = "APEX Animation"
-    product_type = "animation"
     product_base_type = "animation"
+    product_type = product_base_type
     icon = "male"
 
     description = "APEX Animation data exported as BGEO file"

--- a/client/ayon_houdini/plugins/publish/validate_apex_animation.py
+++ b/client/ayon_houdini/plugins/publish/validate_apex_animation.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+import hou
+
+import pyblish.api
+from ayon_core.pipeline import PublishValidationError
+from ayon_core.pipeline.publish import RepairAction
+from ayon_houdini.api.action import SelectInvalidAction
+from ayon_houdini.api import plugin
+
+
+class IsolateAnimation(RepairAction):
+    label = "Isolate Animation"
+
+class ValidateAPEXAnim(plugin.HoudiniInstancePlugin):
+    """Validate output node has animation APEX data.
+
+    Check if packed prim files match only "/animation".
+    This is crucial to prevent any issue when loading the animation.
+    """
+    # Should run after ValidateSopOutputNode
+    order = pyblish.api.ValidatorOrder + 0.1
+    families = ["anim"]
+    label = "Validate APEX Animation"
+    actions = [SelectInvalidAction, IsolateAnimation]
+
+    def process(self, instance):
+
+        if not instance.data.get("instance_node"):
+            # Ignore instances without an instance node
+            # e.g. in memory bootstrap instances
+            self.log.debug(
+                "Skipping instance without instance node: {}".format(instance)
+            )
+            return
+
+        invalid_nodes, message = self.get_invalid_with_message(instance)
+        if invalid_nodes:
+            raise PublishValidationError(
+                message,
+                title=self.label
+            )
+
+    @classmethod
+    def get_invalid_with_message(cls, instance):
+
+        output_node = instance.data.get("output_node")
+
+        geo = output_node.geometry()
+
+        # TODO: Check if this is a bgeo scene.
+        # Same as the error in the Rig Tree
+        # Invalid Hierarchy: No valid roots found, possible closed polygon
+
+        anim_paths = set(geo.extractPackedPaths('/anim**'))
+        if not anim_paths:
+            error = (
+                f"Output SOP node '{output_node}' doesn't"
+                " have 'animation' folder to export."
+                " Please check your RigTree."
+            )
+            return [output_node, error]
+
+        all_paths = set(geo.extractPackedPaths('/**')) - set("/")
+
+        if all_paths != anim_paths:
+            error = (
+                f"Output SOP node '{output_node.path()}' should only"
+                " have 'animation' folder in RigTree."
+            )
+            return [output_node, error]
+
+        return [None, None]
+
+    @classmethod
+    def get_invalid(cls, instance):
+        node, _ = cls.get_invalid_with_message(instance)
+        return [node]
+
+    @classmethod
+    def repair(cls, instance):
+        """Isolate Animation Action.
+
+        It is a helper action more than a repair action,
+        used to add a default single value for the path.
+        """
+
+        output_node = instance.data.get("output_node")
+        if cls.get_invalid(instance) != [output_node]:
+            # Already solved or the error is not related to output node.
+            return
+
+        unpackfolder = output_node.parent().createNode(
+            "unpackfolder", "AUTO_ISOLATE_ANIMATION")
+        unpackfolder.parm("pattern").set("/animation")
+        unpackfolder.parm("unpack").set(0)
+
+        cls.log.debug(f"'{unpackfolder}' was created.")
+
+        unpackfolder.setGenericFlag(hou.nodeFlag.DisplayComment, True)
+        unpackfolder.setComment(
+            "Isolate animation data keeping only 'animation' folder in RigTree"
+        )
+
+        if output_node.type().name() in ["null", "output"]:
+            # Connect before
+            unpackfolder.setFirstInput(output_node.input(0))
+            unpackfolder.moveToGoodPosition()
+            output_node.setFirstInput(unpackfolder)
+            output_node.moveToGoodPosition()
+        else:
+            # Connect after
+            unpackfolder.setFirstInput(output_node)
+
+            rop_node = hou.node(instance.data["instance_node"])
+            rop_node.parm("sop_path").set(unpackfolder.path())
+            unpackfolder.moveToGoodPosition()
+
+            cls.log.debug(
+                f"SOP path on '{rop_node}' updated to new "
+                f"output node '{unpackfolder}'"
+            )


### PR DESCRIPTION
## Changelog Description
This PR is for publishing animation data from packed APEX assets. it was built on top of #371

- Add animation creator
- Add APEX animation validator

## A word on APEX Animation
Typically, this PR allows publishing the animation data only so that we can apply them later in different scenes instead of republishing the whole rig asset again OR publishing baked animation.

As long as artists are using `APEX Scene Copy Animation` node, then everything will be cool.

<img width="978" height="498" alt="image" src="https://github.com/user-attachments/assets/d4bc826f-e08d-49b8-b5f8-47cedc51450f" />

However, when they add a scene animate node, as soon as they go through animation mode in the scene view, the node will stash the animation data. which means the `copy animation` nodes can be removed and the animation will just be persistent. this is a result of Houdini using stashing. _and, in this sense, I'm afraid loading different animations won't have any effect. and it can be confusing for artists. and this is something not related to AYON/saving animation data as Bgeo._ 
<img width="978" height="647" alt="image" src="https://github.com/user-attachments/assets/2c466463-1afb-4c19-b33f-e7c8e185de48" />


## Additional review information
I made this PR while exploring APEX and AYON, mainly in #366 .
Then to make things cleaner, any needed fixes for publishing APEX were moved to #371 as well as the original requirement for AYON APEX Rigging USD workflow while moving the animation part to this PR.

# Demo
[Turret Example AYON APEX Workflow.zip](https://github.com/user-attachments/files/25741133/Turret.Example.AYON.APEX.Workflow.zip)

https://github.com/user-attachments/assets/b5b85efa-bdcd-434d-97f7-25faf4b576e7

## Testing notes:
1. Add characters and props
2. Create APEX Animation
3. Publish

Resolve #365
