### PR TITLE
Review Instance: Validate camera prim from Lops

### DIFF
--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -47,16 +47,29 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
             return "Scene path does not exist: '{}'".format(path)
 
     def get_invalid_camera_path(self, rop_node):
-        camera_path_parm = rop_node.parm("camera")
-        camera_node = camera_path_parm.evalAsNode()
-        path = camera_path_parm.evalAsString()
-        if not camera_node:
-            return "Camera path does not exist: '{}'".format(path)
-        type_name = camera_node.type().name()
-        if type_name not in {"cam", "lopimportcam"}:
-            return "Camera path is not a camera: '{}' (type: {})".format(
-                path, type_name
-            )
+        opsource = rop_node.parm("opsource").eval()
+
+        if opsource != 1:
+            camera_path_parm = rop_node.parm("camera")
+            camera_node = camera_path_parm.evalAsNode()
+            path = camera_path_parm.evalAsString()
+            if not camera_node:
+                return "Camera path does not exist test: '{}'".format(path)
+            type_name = camera_node.type().name()
+            if type_name not in {"cam", "lopimportcam"}:
+                return "Camera path is not a camera: '{}' (type: {})".format(
+                    path, type_name
+                )
+        else:
+            lop_path = rop_node.parm("loppath").evalAsString()
+            camera_path_parm = rop_node.parm("cameraprim")
+
+            stage = hou.node(lop_path).stage()
+
+            if not stage.GetPrimAtPath(camera_path_parm.evalAsString()):
+                return "Camera prim does not exist: '{}'".format(
+                    camera_path_parm.evalAsString()
+                )
 
     def get_invalid_resolution(self, rop_node):
 

--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -49,7 +49,8 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
     def get_invalid_camera_path(self, rop_node):
         opsource = rop_node.parm("opsource").eval()
 
-        if opsource != 1:
+        if opsource == 0:
+            # Object-level
             camera_path_parm = rop_node.parm("camera")
             camera_node = camera_path_parm.evalAsNode()
             path = camera_path_parm.evalAsString()
@@ -60,7 +61,8 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
                 return "Camera path is not a camera: '{}' (type: {})".format(
                     path, type_name
                 )
-        else:
+        elif opsource == 1:
+            # LOP-level
             lop_path = rop_node.parm("loppath").evalAsString()
             camera_path_parm = rop_node.parm("cameraprim")
 
@@ -70,6 +72,8 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
                 return "Camera prim does not exist: '{}'".format(
                     camera_path_parm.evalAsString()
                 )
+        else:
+            return "Unsupported camera source type: {}".format(opsource)
 
     def get_invalid_resolution(self, rop_node):
 

--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -9,8 +9,8 @@ from ayon_houdini.api import plugin
 
 class ValidateSceneReview(plugin.HoudiniInstancePlugin):
     """Validator Some Scene Settings before publishing the review
-        1. Scene Path
-        2. Resolution
+    1. Scene Path
+    2. Resolution
     """
 
     order = pyblish.api.ValidatorOrder
@@ -35,9 +35,7 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
             report.extend(invalid)
 
         if report:
-            raise PublishValidationError(
-                "\n\n".join(report),
-                title=self.label)
+            raise PublishValidationError("\n\n".join(report), title=self.label)
 
     def get_invalid_scene_path(self, rop_node):
         scene_path_parm = rop_node.parm("scenepath")
@@ -74,7 +72,7 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
 
             if not camera_prim or not camera_prim.IsValid():
                 return f"Camera prim path does not exist: '{camera_path}'"
-            
+
             if not camera_prim.IsA(pxr.UsdGeom.Camera):
                 return f"Camera path '{camera_path}' is not a camera."
 

--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -54,7 +54,7 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
             camera_node = camera_path_parm.evalAsNode()
             path = camera_path_parm.evalAsString()
             if not camera_node:
-                return "Camera path does not exist test: '{}'".format(path)
+                return "Camera path does not exist: '{}'".format(path)
             type_name = camera_node.type().name()
             if type_name not in {"cam", "lopimportcam"}:
                 return "Camera path is not a camera: '{}' (type: {})".format(

--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -47,6 +47,9 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
             return "Scene path does not exist: '{}'".format(path)
 
     def get_invalid_camera_path(self, rop_node):
+
+        import pxr
+
         opsource = rop_node.parm("opsource").eval()
 
         if opsource == 0:
@@ -64,14 +67,17 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
         elif opsource == 1:
             # LOP-level
             lop_path = rop_node.parm("loppath").evalAsString()
-            camera_path_parm = rop_node.parm("cameraprim")
+            camera_path = rop_node.parm("cameraprim").evalAsString()
 
             stage = hou.node(lop_path).stage()
+            camera_prim = stage.GetPrimAtPath(camera_path)
 
-            if not stage.GetPrimAtPath(camera_path_parm.evalAsString()):
-                return "Camera prim does not exist: '{}'".format(
-                    camera_path_parm.evalAsString()
-                )
+            if not camera_prim or not camera_prim.IsValid():
+                return f"Camera prim path does not exist: '{camera_path}'"
+            
+            if not camera_prim.IsA(pxr.UsdGeom.Camera):
+                return f"Camera path '{camera_path}' is not a camera."
+
         else:
             return "Unsupported camera source type: {}".format(opsource)
 


### PR DESCRIPTION
## Changelog Description
Added supoprt fro LOP cameras.

## Additional review information
Refactored the [get_invalid_camera_path] method to handle both OBJ and LOP (USD) camera validation.
For OBJ nodes, the function checks if the camera path exists and is a valid camera node (cam or lopimportcam) stayed the same as how it was.
For LOP nodes (opsource == 1), the function retrieves the LOP network from the loppath parameter and checks if the specified USD camera prim exists in the stage.

Fix #170 

## Testing notes:
Create or open a Houdini scene with an LOP (USD) camera setups.
Assign the appropriate camera path or USD camera prim to the review node.
Run the Ayon publisher and trigger the review validation.

Confirm that:
For LOP, missing or invalid USD camera prims are correctly reported.
