### PR TITLE
Implement Run Script workfile template builder placeholder

### DIFF
--- a/client/ayon_houdini/api/workfile_template_builder.py
+++ b/client/ayon_houdini/api/workfile_template_builder.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
 from typing import Any
 import hou
 
 from ayon_core.pipeline import registered_host
 from ayon_core.pipeline.workfile.workfile_template_builder import (
     AbstractTemplateBuilder,
-    PlaceholderPlugin
+    PlaceholderPlugin,
+    PlaceholderItem,
 )
 from ayon_core.tools.workfile_template_build import (
     WorkfileBuildPlaceholderDialog,
@@ -68,7 +70,7 @@ class HoudiniPlaceholderPlugin(PlaceholderPlugin):
 
     attr_prefix: str = "AYON_placeholder_"
 
-    def get_placeholder_node_name(self, placeholder_data):
+    def get_placeholder_node_name(self, placeholder_data) -> str:
         return self.identifier.replace(".", "_")
 
     def create_placeholder_node(self, node_name=None):
@@ -98,7 +100,7 @@ class HoudiniPlaceholderPlugin(PlaceholderPlugin):
         placeholder_data["plugin_identifier"] = self.identifier
         self._imprint(placeholder_node, placeholder_data)
 
-    def collect_scene_placeholders(self):
+    def collect_scene_placeholders(self) -> list[hou.Node]:
         # Read the cache by identifier
         placeholder_nodes = self.builder.get_shared_populate_data(
             self.identifier
@@ -119,6 +121,18 @@ class HoudiniPlaceholderPlugin(PlaceholderPlugin):
                 )
 
         return placeholder_nodes
+
+    def collect_placeholders(self) -> list[PlaceholderItem]:
+        output = []
+        placeholder_nodes = self.collect_scene_placeholders()
+
+        for node in placeholder_nodes:
+            placeholder_data = self._read(node)
+            output.append(
+                PlaceholderItem(node.path(), placeholder_data, self)
+            )
+
+        return output
 
     def update_placeholder(self, placeholder_item, placeholder_data):
         placeholder_node = hou.node(placeholder_item.scene_identifier)

--- a/client/ayon_houdini/plugins/workfile_build/script_placeholder.py
+++ b/client/ayon_houdini/plugins/workfile_build/script_placeholder.py
@@ -1,0 +1,217 @@
+from ayon_houdini.api.lib import find_active_network
+from ayon_houdini.api.workfile_template_builder import (
+    HoudiniPlaceholderPlugin
+)
+from ayon_core.lib import NumberDef, TextDef
+from ayon_core.lib.events import weakref_partial
+
+import hou
+
+
+EXAMPLE_SCRIPT = """
+import hou
+
+# Access the placeholder node (also via hou.pwd())
+placeholder_identifier = placeholder.scene_identifier
+placeholder_node = hou.node(placeholder_identifier)
+
+# Access the event callback
+if event is None:
+    print(f"Populating {placeholder}")
+else:
+    if event.topic == "template.depth_processed":
+        print(f"Processed depth: {event.get('depth')}")
+    elif event.topic == "template.finished":
+        print("Build finished.")
+""".strip()
+
+
+class HoudiniPlaceholderScriptPlugin(HoudiniPlaceholderPlugin):
+    """Execute a script at the given `order` during workfile build.
+
+    This is a very low-level placeholder to run Python scripts at a given
+    point in time during the workfile template build.
+
+    """
+
+    identifier = "houdini.runscript"
+    label = "Run Python Script"
+
+    def get_placeholder_options(self, options=None):
+        options = options or {}
+        return [
+            NumberDef(
+                "order",
+                label="Order",
+                default=options.get("order") or 0,
+                decimals=0,
+                minimum=0,
+                maximum=999,
+                tooltip=(
+                    "Order"
+                    "\nOrder defines asset loading priority (0 to 999)"
+                    "\nPriority rule is : \"lowest is first to load\"."
+                )
+            ),
+            TextDef(
+                "prepare_script",
+                label="Run at\nprepare",
+                tooltip="Run before populate at prepare order",
+                multiline=True,
+                default=options.get("prepare_script", "")
+            ),
+            TextDef(
+                "populate_script",
+                label="Run at\npopulate",
+                tooltip="Run script at populate node order<br>"
+                        "This is the <b>default</b> behavior",
+                multiline=True,
+                default=options.get("populate_script", EXAMPLE_SCRIPT)
+            ),
+            TextDef(
+                "depth_processed_script",
+                label="Run after\ndepth\niteration",
+                tooltip="Run script after every build depth iteration",
+                multiline=True,
+                default=options.get("depth_processed_script", "")
+            ),
+            TextDef(
+                "finished_script",
+                label="Run after\nbuild",
+                tooltip=(
+                    "Run script at build finished.<br>"
+                    "<b>Note</b>: this even runs if other placeholders had "
+                    "errors during the build"
+                ),
+                multiline=True,
+                default=options.get("finished_script", "")
+            ),
+        ]
+
+    def prepare_placeholders(self, placeholders):
+        super().prepare_placeholders(placeholders)
+        for placeholder in placeholders:
+            prepare_script = placeholder.data.get("prepare_script")
+            if not prepare_script:
+                continue
+
+            self.run_script(placeholder, prepare_script)
+
+    def populate_placeholder(self, placeholder):
+        populate_script = placeholder.data.get("populate_script")
+        depth_script = placeholder.data.get("depth_processed_script")
+        finished_script = placeholder.data.get("finished_script")
+
+        # Enforce value not being a float
+        order = int(placeholder.order)
+
+        # Run now
+        if populate_script:
+            self.run_script(placeholder, populate_script)
+
+        if not any([depth_script, finished_script]):
+            # No callback scripts to run
+            if not placeholder.data.get("keep_placeholder", True):
+                self.delete_placeholder(placeholder)
+            return
+
+        # Run at each depth processed
+        if depth_script:
+            callback = weakref_partial(
+                self.run_script, placeholder, depth_script)
+            self.builder.add_on_depth_processed_callback(
+                callback, order=order)
+
+        # Run at build finish
+        if finished_script:
+            callback = weakref_partial(
+                self.run_script, placeholder, finished_script)
+            self.builder.add_on_finished_callback(
+                callback, order=order)
+
+        # If placeholder should be deleted, delete it after finish so
+        # the scripts have access to it up to the last run
+        if not placeholder.data.get("keep_placeholder", True):
+            delete_callback = weakref_partial(
+                self.delete_placeholder, placeholder)
+            self.builder.add_on_finished_callback(
+                delete_callback, order=order + 1)
+
+    def run_script(self, placeholder, script, event=None):
+        """Run script
+
+        Even though `placeholder` is an unused arguments by exposing it as
+        an input argument it means it makes it available through
+        globals()/locals() in the `exec` call, giving the script access
+        to the placeholder.
+
+        For example:
+        >>> node = placeholder.scene_identifier
+
+        In the case the script is running at a callback level (not during
+        populate) then it has access to the `event` as well, otherwise the
+        value is None if it runs during `populate_placeholder` directly.
+
+        For example adding this as the callback script:
+        >>> if event is not None:
+        >>>     if event.topic == "on_depth_processed":
+        >>>         print(f"Processed depth: {event.get('depth')}")
+        >>>     elif event.topic == "on_finished":
+        >>>         print("Build finished.")
+
+        """
+        self.log.debug(f"Running script at event: {event}")
+
+        # Set current node so script can easily access the node via `hou.pwd()`
+        original_pwd = hou.pwd()
+        try:
+            hou.cd(placeholder.scene_identifier)
+            exec(script, locals())
+        finally:
+            try:
+                hou.setPwd(original_pwd)
+            except hou.Error:
+                pass
+
+    def create_placeholder_node(self, node_name=None) -> hou.Node:
+        """Create node to be used as placeholder.
+
+        Create it in the first valid panel the user has open, if none found
+        than fallback to `/obj`. By creating it in the current network the
+        user is working in, it will adapt the null to the relevant type the
+        user may want to run the scripts in - getting a better context.
+        """
+        categories = hou.nodeTypeCategories()
+
+        # Consider only categories that support a `null` node type.
+        categories = {
+            name: category for name, category in categories.items()
+            if category.nodeType("null")
+        }
+
+        # Prioritize certain categories
+        order = ["Sop", "Lop", "Object", "Cop", "Cop2", "Driver", "Top"]
+        order = {key: index for index, key in enumerate(order)}
+        categories = {
+            name: category for name, category
+            in sorted(categories.items(), key=lambda x: order.get(x[0], 1000))
+        }
+
+        for category in categories.values():
+            network = find_active_network(category, default=None)
+            if network is not None:
+                break
+        else:
+            network = hou.node("/obj")
+
+        node = network.createNode(
+            "null", node_name, force_valid_node_name=True)
+        node.moveToGoodPosition()
+        parms = node.parmTemplateGroup()
+        for parm in {"execute", "renderdialog"}:
+            p = parms.find(parm)
+            if p:
+                p.hide(True)
+                parms.replace(parm, p)
+        node.setParmTemplateGroup(parms)
+        return node


### PR DESCRIPTION
## Changelog Description

Implement Run Script workfile template builder placeholder

## Additional review information

The run script placeholder will create itself in the currently opened panel the user has open and hence matches the "null" type for that node network. This allows you to put the script placeholder in arbitrary places where you can make sure you have a good context for your script to run and process (e.g. when connected to a certain material network, or using a certain linked connection in SOPs or LOPs)

Example scripts for the placeholders could be:
```python
print("Hello world")
```

```
import hou

node = hou.pwd()
print(node.path())
```

```
import hou

# Access the placeholder node (also via hou.pwd())
placeholder_identifier = placeholder.scene_identifier
placeholder_node = hou.node(placeholder_identifier)

# Access the event callback
if event is None:
    print(f"Populating {placeholder}")
else:
    if event.topic == "template.depth_processed":
        print(f"Processed depth: {event.get('depth')}")
    elif event.topic == "template.finished":
        print("Build finished.")
```

Fix #391 


## Testing notes:

1. Run Script placeholder should work
2. Load and Create placeholders should also still work