### PR TITLE
Fix typo in settings argument `decription` -> `description`

### DIFF
--- a/server/settings/create.py
+++ b/server/settings/create.py
@@ -5,7 +5,7 @@ class ProductTypeItemModel(BaseSettingsModel):
     _layout = "compact"
     product_type: str = SettingsField(
         title="Product Type",
-        decription="Product type name"
+        description="Product type name"
     )
     label: str = SettingsField(
         "",


### PR DESCRIPTION
## Changelog Description

Fix typo in settings argument `decription` -> `description`

## Additional review information

Fix warning:
```
DEBUG   settings.settings_field    | Unsupported argument: decription at /addons/houdini/0.10.1+dev/server/settings/create.py:6
```

## Testing notes:

1. Description should now work on `product_type`