### PR TITLE
allow CollectFarmInstances to run for all families

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_farm_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_farm_instances.py
@@ -6,7 +6,6 @@ class CollectFarmInstances(plugin.HoudiniInstancePlugin):
     """Collect instances for farm render."""
 
     order = pyblish.api.CollectorOrder - 0.49
-    families = ["*"]
 
     targets = ["local", "remote"]
     label = "Collect farm instances"

--- a/client/ayon_houdini/plugins/publish/collect_farm_instances.py
+++ b/client/ayon_houdini/plugins/publish/collect_farm_instances.py
@@ -6,16 +6,7 @@ class CollectFarmInstances(plugin.HoudiniInstancePlugin):
     """Collect instances for farm render."""
 
     order = pyblish.api.CollectorOrder - 0.49
-    families = ["mantra_rop",
-                "karma_rop",
-                "redshift_rop",
-                "arnold_rop",
-                "vray_rop",
-                "usdrender",
-                "ass","pointcache", "redshiftproxy",
-                "vdbcache", "model", "staticMesh",
-                "rop.opengl", "usdrop", "camera",
-                "apex"]
+    families = ["*"]
 
     targets = ["local", "remote"]
     label = "Collect farm instances"


### PR DESCRIPTION
## Changelog Description
replaces the list of `families` on `CollectFarmInstances` with `*` to allow it running on all families (including `image_rop`)

## Additional review information

<img width="1360" height="1149" alt="image" src="https://github.com/user-attachments/assets/702ca7d9-e60b-41be-b2ef-8da28066ec30" />

`CollectFarmInstances` is supposed to remove  `publish.hou` form the families when running local, but it did not run for  `image_rop` families
This later down the line causes `HoudiniCacheSubmitDeadline` to trigger, even for local products, and fail because `CollectDeadlineServerFromInstance` is using [different logic](https://github.com/vincentullmann/ayon-deadline/blob/develop/client/ayon_deadline/plugins/publish/global/collect_deadline_server_from_instance.py#L38-L40) to differentiate between local and farm products

:warning: I've only done limited testing on this. I am not sure if there are any families that do need to be excluded, in which case maintaining a long list of "allowed families" might make more sense.


## Testing notes:
1. create a cops network with some test nodes (eg.: a `constant`)
2. open the AYON Creator and create a "Composite (Copernicus)" product
3. set render target to "local" render
4. publish

failed publish log
[publish-report-260611-17-03.json](https://github.com/user-attachments/files/28846321/publish-report-260611-17-03.json)



