### PR TITLE
USD Look: Do not collect invokegraph.py, unresolvable relative paths and AYON entity URIs

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -7,10 +7,10 @@ import dataclasses
 
 import pyblish.api
 
-from ayon_houdini.api.usd import get_layer_save_path
 from pxr import Sdf
 
 from ayon_houdini.api import plugin
+from ayon_houdini.api.usd import get_layer_save_path
 
 
 # Colorspace attributes differ per renderer implementation in the USD data

--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -120,7 +120,7 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
                 )
             )
         else:
-            self.log.debug("Collected no assets.")
+            self.log.debug("Collected no assets")
 
     def get_layer_assets(self, layers: List[Sdf.Layer]) -> List[Resource]:
         # TODO: Correctly resolve paths using Asset Resolver.

--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -6,6 +6,8 @@ from typing import List, Optional
 import dataclasses
 
 import pyblish.api
+
+from ayon_houdini.api.usd import get_layer_save_path
 from pxr import Sdf
 
 from ayon_houdini.api import plugin
@@ -111,11 +113,14 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
                     file_label = f"- {filepath}"
                 all_files.append(file_label)
 
-        self.log.info(
-            "Collected assets:\n{}".format(
-                "\n".join(all_files)
+        if all_files:
+            self.log.info(
+                "Collected assets:\n{}".format(
+                    "\n".join(all_files)
+                )
             )
-        )
+        else:
+            self.log.debug("Collected no assets.")
 
     def get_layer_assets(self, layers: List[Sdf.Layer]) -> List[Resource]:
         # TODO: Correctly resolve paths using Asset Resolver.
@@ -154,6 +159,44 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
                     continue
 
                 filepath = asset.path.replace("\\", "/")
+
+                # Skip certain filenames, like `invokegraph.py`
+                if filepath == "invokegraph.py":
+                    self.log.debug(f"Skipping asset at '{path}': {filepath}")
+                    continue
+
+                # Skip AYON entity URIs because these represent already
+                # published files.
+                if filepath.startswith(("ayon://", "ayon+entity://")):
+                    self.log.debug(
+                        "Skipping AYON Entity URI at "
+                        f"'{path}': {filepath}"
+                    )
+                    continue
+
+                # Anchor relative paths to absolute paths
+                if filepath.startswith("./"):
+                    # USD can't anchor to anonymous layers because it doesn't
+                    # know where it exists - however, Houdini layers can have
+                    # dedicated save paths, and hence could resolve paths
+                    # relative to that.
+                    if layer.anonymous:
+                        layer_path = get_layer_save_path(layer)
+                        if layer_path:
+                            folder = os.path.dirname(layer_path)
+                            filepath = os.path.join(folder, filepath[2:])
+                        else:
+                            self.log.warning(
+                                "Skipping asset with relative path."
+                                " USD layer's path is unknown so"
+                                " we cannot resolve the full path for"
+                                f" attribute '{path}': {filepath}"
+                            )
+                            continue
+                    else:
+                        filepath = Sdf.ComputeAssetPathRelativeToLayer(
+                            layer, filepath
+                        )
 
                 # Expand <UDIM> to all files of the available files on disk
                 # TODO: Add support for `<TILE>`

--- a/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
+++ b/client/ayon_houdini/plugins/publish/collect_usd_look_assets.py
@@ -140,6 +140,10 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
                 if spec.typeName != "asset":
                     continue
 
+                # Skip Houdini procedurals
+                if self._is_houdini_procedural_path(path):
+                    continue
+
                 if spec.default is None:
                     # This may happen if no default value is authored. Likely
                     # the property is animated or only custom metadata is set
@@ -159,11 +163,6 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
                     continue
 
                 filepath = asset.path.replace("\\", "/")
-
-                # Skip certain filenames, like `invokegraph.py`
-                if filepath == "invokegraph.py":
-                    self.log.debug(f"Skipping asset at '{path}': {filepath}")
-                    continue
 
                 # Skip AYON entity URIs because these represent already
                 # published files.
@@ -229,6 +228,11 @@ class CollectUsdLookAssets(plugin.HoudiniInstancePlugin):
         resources.sort(key=lambda r: r.source)
 
         return resources
+
+    def _is_houdini_procedural_path(self, path: Sdf.Path) -> bool:
+        """Return whether path represents a Houdini procedural asset path."""
+        procedural_marker = "houdini:procedural:path"
+        return procedural_marker in path.pathString
 
     def get_colorspace(self, spec: Sdf.AttributeSpec) -> Optional[str]:
         """Return colorspace for a Asset attribute spec.


### PR DESCRIPTION
## Changelog Description

Skip collecting `invokegraph.py`, skip AYON entity URIs and allow mapping relative paths to full paths when relevant.

## Additional review information

Fix https://github.com/ynput/ayon-houdini/issues/397

See [reproducable scene shared in private](https://discord.com/channels/517362899170230292/1514632185985106041/1514657779619463250) (I failed to remove some private info from the scene header, even if I copied the nodes to another hip file - so I gave up sharing it here)

## Testing notes:

1. Look publish with houdinifeatherprocedural in graph should work
