### PR TITLE
fix: remove deprecated load from library

### DIFF
--- a/client/ayon_houdini/startup/MainMenuCommon.xml
+++ b/client/ayon_houdini/startup/MainMenuCommon.xml
@@ -76,16 +76,6 @@ host_tools.show_scene_inventory(parent)
 ]]></scriptCode>
             </scriptItem>
 
-            <scriptItem id="library_load">
-                <label>Library...</label>
-                <scriptCode><![CDATA[
-import hou
-from ayon_core.tools.utils import host_tools
-parent = hou.qt.mainWindow()
-host_tools.show_library_loader(parent=parent)
-]]></scriptCode>
-            </scriptItem>
-
             <separatorItem/>
 
             <scriptItem id="workfiles">


### PR DESCRIPTION
## Changelog Description
remove deprecated `Library...` option form the menu

## Additional review information
`host_tools.show_library_loader` was removed in https://github.com/ynput/ayon-core/pull/1856
<img width="666" height="360" alt="Screenshot-8" src="https://github.com/user-attachments/assets/b9e69cd1-b228-4b7d-89cf-2c6da9b23a0a" />


## Testing notes:
1. start with this step
2. follow this step
