### PR TITLE
Add python3.13libs to support Houdini 22

### DIFF
--- a/client/ayon_houdini/startup/python3.13libs/pythonrc.py
+++ b/client/ayon_houdini/startup/python3.13libs/pythonrc.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+"""AYON startup script."""
+from ayon_core.pipeline import install_host
+from ayon_houdini.api import HoudiniHost
+
+
+def main():
+    print("Installing AYON ...")
+    install_host(HoudiniHost())
+
+
+main()


### PR DESCRIPTION
## Changelog Description

Add python3.13libs to support Houdini 22

## Additional review information

Without this Houdini 22 would not trigger the startup scripts.

## Testing notes:

1. Houdini 22 should work.