### PR TITLE
Remove `CollectFarmCacheFamily` plugin

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_cache_farm.py
+++ b/client/ayon_houdini/plugins/publish/collect_cache_farm.py
@@ -7,24 +7,6 @@ from ayon_houdini.api import (
 )
 
 
-class CollectFarmCacheFamily(plugin.HoudiniInstancePlugin):
-    """Collect publish.hou family for caching on farm as early as possible."""
-    order = pyblish.api.CollectorOrder - 0.45
-    families = ["ass", "pointcache", "redshiftproxy",
-                "vdbcache", "model", "staticMesh",
-                 "rop.opengl", "usdrop", "camera"]
-    targets = ["local", "remote"]
-    label = "Collect Data for Cache"
-
-    def process(self, instance):
-
-        if not instance.data["farm"]:
-            self.log.debug("Caching on farm is disabled. "
-                           "Skipping farm collecting.")
-            return
-        instance.data["families"].append("publish.hou")
-
-
 class CollectDataforCache(plugin.HoudiniInstancePlugin):
     """Collect data for caching to Deadline."""
 


### PR DESCRIPTION
## Changelog Description
- Remove `CollectFarmCacheFamily` plugin

## Additional review information
This is a follow up PR to https://github.com/ynput/ayon-houdini/pull/317 which added the removal of `publish.hou` which is done at the same order `pyblish.api.CollectorOrder - 0.49`. 
Which makes `CollectFarmCacheFamily` redundant. 

## Testing notes:
1. Publishing cache to redner farm should work as before.

Resolve https://github.com/ynput/ayon-deadline/issues/173