### PR TITLE
disable CPU (XPU) toggle to set KARMA_XPU_DISABLE_EMBREE_DEVICE on renders

### DIFF
--- a/client/ayon_houdini/plugins/create/create_karma_rop.py
+++ b/client/ayon_houdini/plugins/create/create_karma_rop.py
@@ -22,7 +22,7 @@ class CreateKarmaROP(plugin.RenderLegacyProductTypeCreator):
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
 
-        for key in ["render_target", "review"]:
+        for key in ["render_target", "review", "xpu_disable_cpu"]:
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
@@ -101,6 +101,14 @@ class CreateKarmaROP(plugin.RenderLegacyProductTypeCreator):
                     label="Review",
                     tooltip="Mark as reviewable",
                     default=True),
+            BoolDef("xpu_disable_cpu",
+                    label="Disable CPU (XPU)",
+                    tooltip="Disable the Embree (CPU) device so Karma XPU "
+                            "renders on GPU devices only.\n"
+                            "Sets KARMA_XPU_DISABLE_EMBREE_DEVICE=1 in the "
+                            "farm job environment. Only affects renders with "
+                            "the XPU rendering engine.",
+                    default=False),
             EnumDef("render_target",
                     items=render_target_items,
                     label="Render target",

--- a/client/ayon_houdini/plugins/create/create_usdrender.py
+++ b/client/ayon_houdini/plugins/create/create_usdrender.py
@@ -40,7 +40,7 @@ class CreateUSDRender(plugin.RenderLegacyProductTypeCreator):
         creator_attributes = instance_data.setdefault(
             "creator_attributes", dict())
 
-        for key in ["render_target", "review"]:
+        for key in ["render_target", "review", "xpu_disable_cpu"]:
             if key in pre_create_data:
                 creator_attributes[key] = pre_create_data[key]
 
@@ -136,6 +136,14 @@ class CreateUSDRender(plugin.RenderLegacyProductTypeCreator):
                     label="Review",
                     tooltip="Mark as reviewable",
                     default=True),
+            BoolDef("xpu_disable_cpu",
+                    label="Disable CPU (XPU)",
+                    tooltip="Disable the Embree (CPU) device so Karma XPU "
+                            "renders on GPU devices only.\n"
+                            "Sets KARMA_XPU_DISABLE_EMBREE_DEVICE=1 in the "
+                            "farm job environment. Only affects renders with "
+                            "the Karma XPU renderer.",
+                    default=False),
             EnumDef("render_target",
                     items=render_target_items,
                     label="Render target",

--- a/client/ayon_houdini/plugins/publish/collect_karma_xpu_device.py
+++ b/client/ayon_houdini/plugins/publish/collect_karma_xpu_device.py
@@ -1,0 +1,30 @@
+import pyblish.api
+
+from ayon_core.pipeline.publish import FARM_JOB_ENV_DATA_KEY
+
+from ayon_houdini.api import plugin
+
+
+class CollectKarmaXPUDevice(plugin.HoudiniInstancePlugin):
+    """Collect farm job environment to restrict the Karma XPU devices.
+    """
+
+    # runs after `CollectFarmInstances` so `farm` is collected.
+    order = pyblish.api.CollectorOrder
+    label = "Collect Karma XPU Device"
+    families = ["karma_rop", "usdrender"]
+
+    def process(self, instance):
+        creator_attribute = instance.data["creator_attributes"]
+
+        if not creator_attribute.get("xpu_disable_cpu"):
+            return
+
+        if not instance.data.get("farm"):
+            self.log.info("Instance doesn't render on farm. "
+                           "Skipping Karma XPU device environment.")
+            return
+
+        job_env = instance.data.setdefault(FARM_JOB_ENV_DATA_KEY, {})
+        job_env["KARMA_XPU_DISABLE_EMBREE_DEVICE"] = "1"
+        self.log.info("Karma XPU restricted to GPU devices.")


### PR DESCRIPTION
## Add Karma XPU "Disable CPU" toggle

Adds a `Disable CPU (XPU)` toggle to the Karma ROP and USD Render creators.

When enabled, `KARMA_XPU_DISABLE_EMBREE_DEVICE=1` is added to the farm job environment, so Karma XPU renders on GPU devices only.

Only applies to farm renders with the Karma XPU engine/renderer (ignored otherwise).

We observed some great performance enhancement on some scenes when disabling the CPU usage on our farm XPU renders. 
