### PR TITLE
USD Render - use stage metadata instead of hardcoded rendersettings path

### DIFF
--- a/client/ayon_houdini/api/usd.py
+++ b/client/ayon_houdini/api/usd.py
@@ -341,7 +341,7 @@ def get_usd_render_rop_rendersettings(rop_node, stage=None, logger=None):
     path = rop_node.evalParm("rendersettings")
     if not path:
         # Default behavior
-        path = "/Render/rendersettings"
+        path = stage.GetMetadata("renderSettingsPrimPath")
 
     prim = stage.GetPrimAtPath(path)
     if not prim:

--- a/client/ayon_houdini/api/usd.py
+++ b/client/ayon_houdini/api/usd.py
@@ -340,7 +340,7 @@ def get_usd_render_rop_rendersettings(rop_node, stage=None, logger=None):
 
     path = (
         rop_node.evalParm("rendersettings")
-        or stage.GetMetadata("renderSettingsPrimPath") 
+        or stage.GetMetadata("renderSettingsPrimPath")
         or "/Render/rendersettings"
     )
 

--- a/client/ayon_houdini/api/usd.py
+++ b/client/ayon_houdini/api/usd.py
@@ -338,10 +338,11 @@ def get_usd_render_rop_rendersettings(rop_node, stage=None, logger=None):
         lop_node = get_usd_rop_loppath(rop_node)
         stage = lop_node.stage()
 
-    path = rop_node.evalParm("rendersettings")
-    if not path:
-        # Default behavior
-        path = stage.GetMetadata("renderSettingsPrimPath")
+    path = (
+        rop_node.evalParm("rendersettings")
+        or stage.GetMetadata("renderSettingsPrimPath") 
+        or "/Render/rendersettings"
+    )
 
     prim = stage.GetPrimAtPath(path)
     if not prim:

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -53,8 +53,10 @@ class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
 
         if not instance.data.get("files", []):
             node = hou.node(node_path)
+            lop_stage = node.parm("loppath").evalAsNode().stage()
+            
             rendersettings_path = (
-                node.evalParm("rendersettings") or "/Render/rendersettings"
+                node.evalParm("rendersettings") or lop_stage.GetMetadata("renderSettingsPrimPath")
             )
             raise PublishValidationError(
                 message=(

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -7,7 +7,6 @@ from ayon_core.pipeline import PublishValidationError
 
 from ayon_houdini.api.action import SelectROPAction
 from ayon_houdini.api import plugin
-from ayon_houdini.api.usd import get_usd_render_rop_rendersettings
 
 
 
@@ -55,24 +54,16 @@ class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
 
         if not instance.data.get("files", []):
             node = hou.node(node_path)
-            
-            rendersettings_path = (
-                node.evalParm("rendersettings") 
-                or instance.data["stage"].GetMetadata("renderSettingsPrimPath")
-                or "/Render/rendersettings"
-            )
-
-            if not instance.data["stage"].GetPrimAtPath(rendersettings_path):
-                self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
             stage = instance.data["stage"]
             rendersettings_path: str = (
-                node.evalParm("rendersettings") 
+                node.evalParm("rendersettings")
                 or stage.GetMetadata("renderSettingsPrimPath")
                 or "/Render/rendersettings"
             )
 
             if not stage.GetPrimAtPath(rendersettings_path):
                 self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
+
             raise PublishValidationError(
                 message=(
                     "No Render Products found in Render Settings "

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -61,7 +61,10 @@ class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
             )
 
             if not stage.GetPrimAtPath(rendersettings_path):
-                self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
+                self.log.warning(
+                    "No render settings primitive found at: "
+                    f"{rendersettings_path}"
+                )
 
             raise PublishValidationError(
                 message=(

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -64,7 +64,15 @@ class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
 
             if not instance.data["stage"].GetPrimAtPath(rendersettings_path):
                 self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
+            stage = instance.data["stage"]
+            rendersettings_path: str = (
+                node.evalParm("rendersettings") 
+                or stage.GetMetadata("renderSettingsPrimPath")
+                or "/Render/rendersettings"
+            )
 
+            if not stage.GetPrimAtPath(rendersettings_path):
+                self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
             raise PublishValidationError(
                 message=(
                     "No Render Products found in Render Settings "

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -9,7 +9,6 @@ from ayon_houdini.api.action import SelectROPAction
 from ayon_houdini.api import plugin
 
 
-
 class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
     """Validate at least one render product is present"""
 

--- a/client/ayon_houdini/plugins/publish/validate_render_products.py
+++ b/client/ayon_houdini/plugins/publish/validate_render_products.py
@@ -7,6 +7,8 @@ from ayon_core.pipeline import PublishValidationError
 
 from ayon_houdini.api.action import SelectROPAction
 from ayon_houdini.api import plugin
+from ayon_houdini.api.usd import get_usd_render_rop_rendersettings
+
 
 
 class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
@@ -53,11 +55,16 @@ class ValidateUsdRenderProducts(plugin.HoudiniInstancePlugin):
 
         if not instance.data.get("files", []):
             node = hou.node(node_path)
-            lop_stage = node.parm("loppath").evalAsNode().stage()
             
             rendersettings_path = (
-                node.evalParm("rendersettings") or lop_stage.GetMetadata("renderSettingsPrimPath")
+                node.evalParm("rendersettings") 
+                or instance.data["stage"].GetMetadata("renderSettingsPrimPath")
+                or "/Render/rendersettings"
             )
+
+            if not instance.data["stage"].GetPrimAtPath(rendersettings_path):
+                self.log.warning(f"No render settings primitive found at: {rendersettings_path}")
+
             raise PublishValidationError(
                 message=(
                     "No Render Products found in Render Settings "


### PR DESCRIPTION
## Changelog Description
Uses stage metadata as a fallback instead of hardcoded `/Render/rendersettings` path
Fixes #419 

## Testing notes:
1. Submit usd render with no render settings path set
2. Files should be collected regardless of the rendersettings prim name (as long as it's set as default on the layer)

