### PR TITLE
fix #372: allow all camera types in validate scene review

### DIFF
--- a/client/ayon_houdini/api/lib.py
+++ b/client/ayon_houdini/api/lib.py
@@ -803,6 +803,35 @@ def get_output_children(output_node, include_sops=True):
     return out_list
 
 
+def node_matches_filter(
+    node: hou.Node,
+    node_type_filter: hou.nodeTypeFilter,
+) -> bool:
+    """Check if the given node matches a hou.nodeTypeFilter.
+
+    Args:
+        node (hou.Node): The node to check.
+        node_type_filter (hou.nodeTypeFilter): The node type filter to check.
+
+    Returns:
+        bool: True if the node matches the node type filter, False otherwise.
+
+    """
+    if node_type_filter == hou.nodeTypeFilter.NoFilter:
+        return True
+
+    name = node.name()
+    parent = node.parent() or hou.root()
+
+    # houdini does not seem to have a simple "node matches filter" function
+    # so we repurpose the "recursiveGlob" function here
+    return node in parent.recursiveGlob(
+        pattern=name,
+        filter=node_type_filter,  # ty: ignore[invalid-argument-type]  hou-types has invalid type for filter
+        include_subnets=False,
+    )
+
+
 def get_resolution_from_entity(entity):
     """Get resolution from the given entity.
 

--- a/client/ayon_houdini/plugins/publish/validate_scene_review.py
+++ b/client/ayon_houdini/plugins/publish/validate_scene_review.py
@@ -5,6 +5,7 @@ import pyblish.api
 from ayon_core.pipeline import PublishValidationError
 
 from ayon_houdini.api import plugin
+from ayon_houdini.api.lib import node_matches_filter
 
 
 class ValidateSceneReview(plugin.HoudiniInstancePlugin):
@@ -56,12 +57,15 @@ class ValidateSceneReview(plugin.HoudiniInstancePlugin):
             camera_node = camera_path_parm.evalAsNode()
             path = camera_path_parm.evalAsString()
             if not camera_node:
-                return "Camera path does not exist: '{}'".format(path)
-            type_name = camera_node.type().name()
-            if type_name not in {"cam", "lopimportcam"}:
-                return "Camera path is not a camera: '{}' (type: {})".format(
-                    path, type_name
-                )
+                return f"Camera path does not exist: '{path}'"
+
+            if not node_matches_filter(
+                camera_node,
+                hou.nodeTypeFilter.ObjCamera,  # ty: ignore[invalid-argument-type]  hou-types has invalid type for filter EnumValues
+            ):
+                type_ = camera_node.type().name()
+                return f"Camera path is not a camera: '{path}' (type: {type_})"
+
         elif opsource == 1:
             # LOP-level
             lop_path = rop_node.parm("loppath").evalAsString()


### PR DESCRIPTION
## Changelog Description
Allow all camera types in `ValidateSceneReview`

## Additional review information
added a small helper method `node_matches_filter` to check if a given node matches a given `hou.nodeTypeFilter` and utilise that to validate if a node matches the `hou.nodeTypeFilter.ObjCamera` filter

## Testing notes:
1. create a `Review (opengl)` product
2. create a regular camera, a "special camera" (eg.: "Switcher") and a non camera (eg.: "geo")
3. set the OpenGL rop to use each of these
4. validate

validation should pass for the Camera and swticher and fail for the geo

Example failed message: (same as before)
> Camera path is not a camera: '/obj/geo4' (type: geo)

test script for `node_matches_filter`


```py
import hou

from ayon_houdini.api.lib import node_matches_filter


cam = hou.node("/obj/").createNode("cam")
sop_node = cam.node("file1")
switch = hou.node("/obj/").createNode("switcher")
geo = hou.node("/obj/").createNode("geo")


for node in [sop_node, cam, switch, geo]:
    is_cam = node_matches_filter(node, hou.nodeTypeFilter.ObjCamera)
    is_obj = node_matches_filter(node, hou.nodeTypeFilter.Obj)
    is_sop = node_matches_filter(node, hou.nodeTypeFilter.Sop)
    print(f"{node} {is_cam=} {is_obj=} {is_sop=}")

    node.destroy()
```
expected output
```
file1 is_cam=False is_obj=False is_sop=True
cam7 is_cam=True is_obj=True is_sop=False
switcher1 is_cam=True is_obj=True is_sop=False
geo5 is_cam=False is_obj=True is_sop=False
```

Fix https://github.com/ynput/ayon-houdini/issues/372
