### PR TITLE
Consider frame padding when collecting frames

### DIFF
--- a/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -50,7 +50,10 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
         # clique.PATTERNS["frames"] supports only `.1001.exr` not `_1001.exr`.
         templates = instance.context.data["anatomy"]["templates"]
         frame_padding = int(templates["common"]["frame_padding"])
-        pattern = f"[_.](?P<index>(?P<padding>0*)\\d{{{frame_padding},}}+)\\.\\D+\\d?$"
+        pattern = (
+            f"[_.](?P<index>(?P<padding>0*)\\d{{{frame_padding},}}+)"
+            "\\.\\D+\\d?$"
+        )
         frame_collection, _ = clique.assemble(
             [file_name],
             patterns=[pattern],

--- a/client/ayon_houdini/plugins/publish/collect_frames.py
+++ b/client/ayon_houdini/plugins/publish/collect_frames.py
@@ -48,7 +48,9 @@ class CollectFrames(plugin.HoudiniInstancePlugin):
         # will be <Collection "pointcacheBgeoCache_AB010.%d.bgeo [1001]">
         # we use a customized pattern as
         # clique.PATTERNS["frames"] supports only `.1001.exr` not `_1001.exr`.
-        pattern = "[_.](?P<index>(?P<padding>0*)\\d+)\\.\\D+\\d?$"
+        templates = instance.context.data["anatomy"]["templates"]
+        frame_padding = int(templates["common"]["frame_padding"])
+        pattern = f"[_.](?P<index>(?P<padding>0*)\\d{{{frame_padding},}}+)\\.\\D+\\d?$"
         frame_collection, _ = clique.assemble(
             [file_name],
             patterns=[pattern],


### PR DESCRIPTION
## Changelog Description
Consider frame padding when collecting frames

## Testing notes:
1. create point cache product while scenefile's frame range is not one frame
2. validate and publish. 
3. additionally, you can see `frames` instance data which should be empty as the collection is empty (no frame pattern detected).
